### PR TITLE
Make actions throw by default.

### DIFF
--- a/spec/model.spec.ts
+++ b/spec/model.spec.ts
@@ -1,5 +1,6 @@
 import { isStateTreeNode } from "mobx-state-tree";
 import { types } from "../src";
+import { CantRunActionError } from "../src/errors";
 import { $identifier } from "../src/symbols";
 import { TestModel, TestModelSnapshot } from "./fixtures/TestModel";
 
@@ -82,10 +83,10 @@ describe("is", () => {
 });
 
 describe("actions", () => {
-  test("succeed on a read-only instance", () => {
+  test("throw on a read-only instance", () => {
     const m = TestModel.createReadOnly(TestModelSnapshot);
-    m.setB(false);
-    expect(m.bool).toEqual(false);
+    expect(() => m.setB(false)).toThrowError(CantRunActionError);
+    expect(m.bool).toEqual(true);
   });
 
   test("succeed on an MST instance", () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,1 @@
+export class CantRunActionError extends Error {}


### PR DESCRIPTION
This allows us to optimize model instantiation, because we can create a prototype for the actions instead of having to call the action initializer on every instantiation.

Verified this passes in Gadget's CI suite, after we made some changes to no longer need actions in our read-only codepaths.