### PR TITLE
Allow readonly/const arrays for types.enumeration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/mobx-quick-tree",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A mirror of mobx-state-tree's API to construct fast, read-only instances that share all the same views",
   "source": "src/index.ts",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -29,18 +29,18 @@
     "mobx-state-tree": "^5.1.3"
   },
   "devDependencies": {
-    "@babel/core": "^7.17.8",
-    "@babel/preset-env": "^7.16.11",
-    "@babel/preset-typescript": "^7.16.7",
+    "@babel/core": "^7.19.0",
+    "@babel/preset-env": "^7.19.0",
+    "@babel/preset-typescript": "^7.18.6",
     "@gadgetinc/eslint-config": "*",
     "@gadgetinc/prettier-config": "*",
-    "@types/jest": "^27.4.1",
-    "@typescript-eslint/eslint-plugin": "^5.16.0",
-    "eslint": "^8.12.0",
-    "eslint-plugin-jest": "^26.1.3",
-    "jest": "^27.5.1",
-    "prettier": "^2.6.1",
-    "typescript": "^4.6.3"
+    "@types/jest": "^29.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.36.2",
+    "eslint": "^8.23.0",
+    "eslint-plugin-jest": "^27.0.1",
+    "jest": "^29.0.2",
+    "prettier": "^2.7.1",
+    "typescript": ">=4.7.0 <4.8.0"
   },
   "volta": {
     "node": "16.14.2"

--- a/spec/model.spec.ts
+++ b/spec/model.spec.ts
@@ -85,7 +85,7 @@ describe("is", () => {
 describe("actions", () => {
   test("throw on a read-only instance", () => {
     const m = TestModel.createReadOnly(TestModelSnapshot);
-    expect(() => m.setB(false)).toThrowError(CantRunActionError);
+    expect(() => m.setB(false)).toThrow(CantRunActionError);
     expect(m.bool).toEqual(true);
   });
 

--- a/spec/simple.spec.ts
+++ b/spec/simple.spec.ts
@@ -211,6 +211,7 @@ describe("custom", () => {
 
 describe("enumeration", () => {
   const enumType = types.enumeration<"a" | "b">(["a", "b"]);
+  const _enumTypeWithConst = types.enumeration<"a" | "b">(["a", "b"] as const);
 
   test("can create a read-only instance", () => {
     expect(enumType.createReadOnly("a")).toEqual("a");

--- a/src/api.ts
+++ b/src/api.ts
@@ -153,6 +153,7 @@ export const getRoot = <T extends IAnyType>(value: IAnyStateTreeNode): Instance<
   }
 
   // Assumes no cycles, otherwise this is an infinite loop
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     const newValue = value[$parent];
     if (newValue) {

--- a/src/array.ts
+++ b/src/array.ts
@@ -9,7 +9,10 @@ export class QuickArray<T extends IAnyType> extends Array<T["InstanceType"]> imp
   }
 
   [$type]?: [this] | [any];
-  [Symbol.toStringTag]: "Array";
+
+  get [Symbol.toStringTag]() {
+    return "Array" as const;
+  }
 
   spliceWithArray(_index: number, _deleteCount?: number, _newItems?: Instance<T>[]): Instance<T>[] {
     throw new Error("cannot spliceWithArray on a QuickArray instance");

--- a/src/enumeration.ts
+++ b/src/enumeration.ts
@@ -3,8 +3,8 @@ import { BaseType } from "./base";
 import type { IAnyStateTreeNode, InstantiateContext, ISimpleType } from "./types";
 
 class EnumerationType<EnumOptions extends string> extends BaseType<EnumOptions, EnumOptions, EnumOptions> {
-  constructor(readonly name: string, readonly options: EnumOptions[]) {
-    super(types.enumeration<EnumOptions>(options));
+  constructor(readonly name: string, readonly options: readonly EnumOptions[]) {
+    super(types.enumeration<EnumOptions>([...options]));
   }
 
   instantiate(snapshot: this["InputType"], _context: InstantiateContext): this["InstanceType"] {
@@ -21,13 +21,13 @@ class EnumerationType<EnumOptions extends string> extends BaseType<EnumOptions, 
 }
 
 type EnumerationFactory = {
-  <EnumOptions extends string>(name: string, options: EnumOptions[]): ISimpleType<EnumOptions>;
-  <EnumOptions extends string>(options: EnumOptions[]): ISimpleType<EnumOptions>;
+  <EnumOptions extends string>(name: string, options: readonly EnumOptions[]): ISimpleType<EnumOptions>;
+  <EnumOptions extends string>(options: readonly EnumOptions[]): ISimpleType<EnumOptions>;
 };
 
 export const enumeration: EnumerationFactory = <EnumOptions extends string>(
-  nameOrOptions: EnumOptions[] | string,
-  options?: EnumOptions[]
+  nameOrOptions: readonly EnumOptions[] | string,
+  options?: readonly EnumOptions[]
 ): ISimpleType<EnumOptions> => {
   let name;
   if (typeof nameOrOptions == "string") {

--- a/src/map.ts
+++ b/src/map.ts
@@ -11,7 +11,10 @@ export class QuickMap<T extends IAnyType> extends Map<string, T["InstanceType"]>
   }
 
   [$type]?: [this] | [any];
-  [Symbol.toStringTag]: "Map";
+
+  get [Symbol.toStringTag]() {
+    return "Map" as const;
+  }
 
   forEach(callbackfn: (value: Instance<T>, key: string, map: this) => void, thisArg?: any): void {
     super.forEach((value, key) => callbackfn(value, key, thisArg ?? this));


### PR DESCRIPTION
This previously didn't work:

```typescript
const values = ["a", "b", "c"] as const;
const MyEnum = types.enumeration(values);
```

We don't mutate this array, so it can be readonly. This allows people to use `as const` on an array and be able to use that as an input to enumeration without special casts or clones, which I think is desirable. This PR corrects the issue.

Also in this PR is a version lock for TypeScript (and bumped all other `devDependencies`). Since we don't have a `yarn.lock` in this repo, we take the latest version that matches the specifier. One of the 4.8 versions was spitting out this error:

```
TypeError: host.fileExists is not a function
```

I had a to make a few other changes to be able to make this happen, far more than the main change in this PR 🙈 