### PR TITLE
Revert typescript bump.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/mobx-quick-tree",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A mirror of mobx-state-tree's API to construct fast, read-only instances that share all the same views",
   "source": "src/index.ts",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -29,18 +29,18 @@
     "mobx-state-tree": "^5.1.3"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.0",
-    "@babel/preset-env": "^7.19.0",
-    "@babel/preset-typescript": "^7.18.6",
+    "@babel/core": "^7.17.8",
+    "@babel/preset-env": "^7.16.11",
+    "@babel/preset-typescript": "^7.16.7",
     "@gadgetinc/eslint-config": "*",
     "@gadgetinc/prettier-config": "*",
-    "@types/jest": "^29.0.0",
-    "@typescript-eslint/eslint-plugin": "^5.36.2",
-    "eslint": "^8.23.0",
-    "eslint-plugin-jest": "^27.0.1",
-    "jest": "^29.0.2",
-    "prettier": "^2.7.1",
-    "typescript": ">=4.7.0 <4.8.0"
+    "@types/jest": "^27.4.1",
+    "@typescript-eslint/eslint-plugin": "^5.16.0",
+    "eslint": "^8.12.0",
+    "eslint-plugin-jest": "^26.1.3",
+    "jest": "^27.5.1",
+    "prettier": "^2.6.1",
+    "typescript": ">=4.6.3 <4.7.0"
   },
   "volta": {
     "node": "16.14.2"


### PR DESCRIPTION
The current version seems to be building broken typescript. Specifically, the error I'm seeing is

```
node_modules/mobx-quick-tree/dist/src/index.d.ts:15:250 - error TS1005: '?' expected.
```

And that line refers to the generated type for `types.compose`, which is quite
large. Although I tested this and it seemed to work, I must have not been using
the built version locally.

I'll unpublish 0.3.1. Even with the version currently specified (4.7.4) the file was considered ill-formatted. Really bizarre 😕 