### PR TITLE
Fix two bugs with identifiers

### DIFF
--- a/spec/api.spec.ts
+++ b/spec/api.spec.ts
@@ -93,6 +93,8 @@ describe("getSnapshot", () => {
     const m = types.model({
       testModels: types.array(TestModel),
       ref: types.reference(NamedThing),
+      safeRef1: types.safeReference(NamedThing),
+      safeRef2: types.safeReference(NamedThing),
     });
 
     const instance = m.createReadOnly({
@@ -101,10 +103,14 @@ describe("getSnapshot", () => {
         { bool: false, nested: { key: "b", name: "b 2" }, frozen: { test: "string" } },
       ],
       ref: "b",
+      safeRef1: "x",
+      safeRef2: "a",
     });
 
     expect(instance.ref.name).toEqual("b 2");
     expect(getSnapshot(instance).ref).toEqual("b");
+    expect(getSnapshot(instance).safeRef1).toBeUndefined();
+    expect(getSnapshot(instance).safeRef2).toEqual("a");
   });
 
   test("returns the proper root for an MST instance", () => {

--- a/spec/map.spec.ts
+++ b/spec/map.spec.ts
@@ -11,6 +11,17 @@ test("can create a map of simple types", () => {
   expect(mapType.createReadOnly({ a: "A", b: "B" }).toJSON()).toEqual(expect.objectContaining({ a: "A", b: "B" }));
 });
 
+test("is can create a map of frozen types from a snapshot", () => {
+  const mapType = types.map(types.frozen<string | null>());
+  const snapshot = { A: "one", B: null };
+  expect(mapType.createReadOnly(snapshot).toJSON()).toEqual(
+    expect.objectContaining({
+      A: "one",
+      B: null,
+    })
+  );
+});
+
 test("can create a map of complex types", () => {
   const mapType = types.map(InventoryItem);
 

--- a/src/map.ts
+++ b/src/map.ts
@@ -2,7 +2,7 @@ import { IInterceptor, IMapDidChange, IMapWillChange, Lambda } from "mobx";
 import { isStateTreeNode, types } from "mobx-state-tree";
 import { BaseType, setParent, setType } from "./base";
 import { getSnapshot } from "./snapshot";
-import { $identifier, $type } from "./symbols";
+import { $type } from "./symbols";
 import type { CreateTypes, IAnyStateTreeNode, IAnyType, IMapType, IMSTMap, Instance, InstantiateContext, SnapshotOut } from "./types";
 
 export class QuickMap<T extends IAnyType> extends Map<string, T["InstanceType"]> implements IMSTMap<T> {
@@ -86,7 +86,7 @@ class MapType<T extends IAnyType> extends BaseType<
       for (const key in snapshot) {
         const item = this.childrenType.instantiate(snapshot[key], context);
         setParent(item, map);
-        map.set(item[$identifier] ?? key, item);
+        map.set(key, item);
       }
     }
 

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -33,7 +33,8 @@ const snapshot = (value: any): unknown => {
       for (const name in type.properties) {
         const propType = type.properties[name];
         if (isReferenceType(propType)) {
-          modelSnapshot[name] = (value as any)[name][$identifier];
+          const maybeRef = (value as any)[name];
+          modelSnapshot[name] = maybeRef?.[$identifier];
         } else {
           modelSnapshot[name] = snapshot((value as any)[name]);
         }


### PR DESCRIPTION
1. When using a frozen type in a map, there can be a key/value pair where the value can be null and hence cannot be indexed for an identifier. MST always uses the key from the snapshot as the key in the map, so we now do the same.
2. Safe references can be undefined, so we shouldn't try to index it for an identifier when creating a snapshot.