### PR TITLE
Class based model API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,36 +4,631 @@
   </p>
   <p>
     <strong>
-      A mirror of the mobx-state-tree API that allows constructing fast, read-only instances.
+      A mirror of the `mobx-state-tree` API that allows constructing fast, read-only instances.
     </strong>
   </p>
 </div>
 
+`mobx-quick-tree` is a wrapper around `mobx-state-tree` that adds a second, interface-identical type for each `mobx-state-tree` type you define that is high-performance, read-only, and no longer observable.
+
 ## Why?
 
-`mobx-state-tree` (MST) is great for modeling in a reactive context, but it can be a bit unwieldy to reuse the view logic in a non-reactive context.
+[`mobx-state-tree`](https://mobx-state-tree.js.org/) is great for modeling data and observing changes to it, but it adds a lot of runtime overhead! Raw `mobx` itself adds substantial overhead over plain old JS objects or ES6 classes, and `mobx-state-tree` adds more on top of that. If you want to use your MST data models in a non-reactive or non-observing context, all that runtime overhead for observability is just wasted, as nothing is ever changing.
 
-`mobx-quick-tree` mirrors the `mobx-state-tree` API so that you can still use all the great MST things you always have, but also allows you to construct a performant, read-only version of the tree.
+`mobx-quick-tree` implements the same API as MST and exposes the same useful observable instances for use in observable contexts, but adds a second option for instantiating a read-only instance that is 100x faster.
 
-## Example
+If `mobx-state-tree` instances are great for modeling within an "editor" part of an app where nodes and properties are changed all over the place, the performant, read-only instances constructed by `mobx-quick-tree` are great for using within a "read" part of an app that displays data in the tree without ever changing it. For a website builder for example, you might use MST in the page builder area where someone arranges components within a page, and then use MQT in the part of the app that needs to render those webpages frequently.
+
+### Two APIs
+
+`mobx-quick-tree` has two APIs for building performant, read-only versions of your models:
+
+- a 100% compatible, drop-in replacement for the `mobx-state-tree` API using `types.model`, `types.compose`, etc
+- an ES6 `class` based API that performs even faster in read-only mode
+
+### Drop-in `mobx-state-tree` API compatibility
+
+To begin using `mobx-quick-tree`, change all your import statements from importing `mobx-state-tree` to import `mobx-quick-tree`. `mobx-quick-tree` exports all the same utilities and objects and maintains the same robust TypeScript support `mobx-state-tree` users are used to.
+
+For example, if you have a `types.model` defined, you can keep the definition entirely the same, but define it using the `types` object imported from `mobx-quick-tree`:
+
+```typescript
+import { types } from "@gadgetinc/mobx-quick-tree"
+
+// use types.model from MQT the exact same way you might use types.model from MST
+const Todo = types.model("Todo", {
+  name: types.string,
+  done: types.boolean
+}).actions(self => {
+  setDone(done: boolean) {
+    self.done = done;
+  }
+});
+```
+
+Once you have a `mobx-quick-tree` type defined, you can use it the same way you might use a `mobx-state-tree` type:
+
+```typescript
+// create an observable instance with `create`, using mobx-state-tree under the hood
+const instance = Todo.create({ name: "Hello", done: false });
+// actions run like normal on observable instances
+instance.setDone(true);
+```
+
+Each defined type also exposes a new `.createReadOnly` function for constructing read only versions of the type:
+
+```typescript
+// create a readonly instance which is ~100x faster
+const readOnlyInstance = Todo.createReadOnly({ name: "Hello read only", done: false });
+readOnlyInstance.setDone(true); // will throw an error, the instance is readonly
+```
+
+`.createReadOnly` exists on models, arrays, maps, etc, and will be used throughout a tree started with a `.createReadOnly` call.
+
+#### API coverage
+
+`mobx-quick-tree` supports the same functionality as `mobx-state-tree` on observable instances, like:
+
+- actions, views, and volatiles
+- references
+- snapshots
+- patch streams
+- middleware
+- full type safety
+
+Many of the pieces of functionality don't make sense to call on read only instances and will throw however. Functions that change data, like `applyPatch` or `applySnapshot` will work as documented in MST against observable instances, but will throw errors when run against read-only instances created with `.createReadOnly`.
+
+Type-level functions like `isModelType` or `isUnionType` report type information correctly when run against types defined using `mobx-quick-tree`.
+
+#### Mixing `mobx-state-tree` and `mobx-quick-tree`.
+
+`mobx-quick-tree` does _not_ support mixing types or instances defined with `mobx-state-tree`. `mobx-quick-tree` can co-exist in the same process, but will error if used in the same tree with `mobx-state-tree`.
+
+If switching from `mobx-state-tree` to `mobx-quick-tree`, we recommend **completely removing** `mobx-state-tree` from your package.json, and switching all import statements over to import from `mobx-quick-tree`.
+
+### ES6 class-based Model API
+
+If you need even more performance, `mobx-quick-tree` has an ES6 class-based API that replaces the pretty-but-slow MST API. The MST API design forces re-running each `views` or `actions` block for each and every instance defined, which adds a lot of overhead and is often not well handled by the JS VM. By using ES6 classes, each view and action can be defined only once at require time, and the prototype chain of the read-only objects can do a lot more of the heavy lifting.
+
+These high-performance classes still allow accessing an observable instance that functions equivalently to a type defined using the `mobx-state-tree` API, so they can still be used in both observable and non-observable contexts.
+
+Readonly instances created with the ES6 Class Model API from `mobx-quick-tree` are 3x faster than the readonly instances created with the MST style API, for a total of a 300x performance improvement.
+
+To define an ES6 class model, you use a different API than `mobx-state-tree` that only `mobx-quick-tree` exports.
+
+For example, a `Todo` class model can be defined like so:
+
+```typescript
+import { register, ClassModel, action, types } from "@gadgetinc/mobx-quick-tree";
+
+@register
+class Todo extends ClassModel({
+  name: types.string,
+  done: types.boolean,
+}) {
+  @action
+  setDone(done: boolean) {
+    this.done = done;
+  }
+}
+
+// create a readonly instance which is ~300x faster
+const readOnlyInstance = Todo.createReadOnly({ name: "Hello read only", done: false });
+readOnlyInstance.setDone(true); // will throw an error, the instance is readonly
+
+// create an observable instance with `create`
+const instance = Todo.create({ name: "Hello", done: false });
+// actions run like normal on observable instances
+instance.setDone(true);
+```
+
+The Class Model API works by using the class you define to power read only instances. Classes are fast to instantiate and are optimized well by JS VMs which makes them ideal for the high performance use case. For the observable instances, the Class Model API derives an equivalent type using `mobx-state-tree`'s `types.model`, and configures it to have all the same properties, views, actions, and volatiles that the class does. The read-only class and writable observable type have identical interfaces at runtime, but will be instances of two different classes.
+
+To access the derived `mobx-state-tree` type explicitly for a class model, you can use the static `.mstType` property.
+
+#### Requirements for using Class Model API
+
+To use the Class Model API and maintain compatibility with both read-only and observable instances, you must adhere to the following rules:
+
+- All Class Models need to subclass a base class created by the `ClassModel` base class generator
+- All Class Models need to be registered using the `@register` decorator
+- All view functions or getters on the class need to be decorated with the `@view` decorator. These are the functions that would be MST `.views()` or raw mobx `computed` functions.
+- All functions which mutate data must be decorated with the `@action` function. These are the functions that would be MST `.actions()` or raw mobx `action` functions.
+- All volatile properties (those excluded from MST snapshots) must be registered with the `@volatile` decorator. These are the properties that would be modeled using MST's `.volatile()` API
+
+#### Setting up a Class Model
+
+Class models are defined using normal ES6 classes that are decorated and extend a special, dynamically generated base class. Class models store data by passing a list of typed properties to store to the `ClassModel` base class generator:
+
+```typescript
+import { ClassModel, register, view, action } from "@gadgetinc/mobx-quick-tree";
+
+@register
+class Car extends ClassModel({
+  make: types.string,
+  model: types.string,
+  year: types.number,
+}) {
+  // define a view with a function and the @view decorator
+  @view
+  name() {
+    // refer to properties of the model with `this`
+    return `${this.year} ${this.model} ${this.make}`;
+  }
+
+  // define an action with a function
+  @action
+  setModel(model: string) {
+    // set  properties of the model on `this`
+    this.model = model;
+  }
+}
+```
+
+Each Class Model **must** be registered with the system using the `@register` decorator in order to be instantiated.
+`@register` is necessary for setting up the internal state of the class and generating the observable MST type.
+
+Within Class Model class bodies, refer to the current instance using the standard ES6/JS `this` keyword. `mobx-state-tree` users tend to use `self` within view or action blocks, but Class Models return to using standard JS `this` for performance.
+
+#### Creating instances of a class model
+
+Once you have a Class Model class created, you can create both read-only instances and observable instances of it.
+
+To create an **observable** instance of a Class Model, use the static `.create` function:
+
+```typescript
+// create an observable instance
+const observableInstance = Car.create({ make: "Toyota", model: "Prius", year: 2008 });
+
+// access properties of the observable, will be observed if run within an observer
+car.make; // => "Toyota"
+
+// run actions to change data and fire observers by calling action functions
+car.setModel("Camry");
+```
+
+To create an **read only** instance of a Class Model, use the static `.createReadOnly` function:
+
+```typescript
+// create an read only instance
+const readOnlyInstance = Car.createReadOnly({ make: "Toyota", model: "Prius", year: 2008 });
+
+// access properties of the observable, will be observed if run within an observer
+car.make; // => "Toyota"
+
+// actions will throw if called on a readonly instance
+// car.setModel("Camry"); => would throw an throw error
+```
+
+##### Differences in using a Class Model and a `types.model`
+
+At runtime, observable instances of Class Models and `types.model` instances behave very similarly. Both are built atop `mobx-state-tree`, so views, mobx `computed`s, `mobx-react` observer components, and any other compatible component of the mobx ecosystem can observe properties on instances of either type.
+
+At runtime, readonly instances of Class Models and readonly `types.model` instances behave similarly. Both are created with the `.createReadOnly` call.
+
+If using TypeScript, Class Model instances and `types.model` instances should be treated slightly differently. `mobx-state-tree` uses the `Instance` helper to refer to instances of a type, like `Instance<typeof Car>`. Since Class Models are real classes, instances of them can be referred to with just the name of the class, like `Car`, without needing to use the `Instance` helper. This matches standard ES6 class behavior.
+
+Quick reference for type-time differences:
+
+| Type                       | `types.model` model         | Class Model model                                   |
+| -------------------------- | --------------------------- | --------------------------------------------------- |
+| Type of an instance        | `Instance<typeof Model>`    | `Model` (though `Instance<typeof Model>` works too) |
+| Input snapshot of a model  | `SnapshotIn<typeof Model>`  | `SnapshotIn<typeof Model>`                          |
+| Output snapshot of a model | `SnapshotOut<typeof Model>` | `SnapshotOut<typeof Model>`                         |
+
+#### Defining views with `@view`
+
+Class Models support views on instances, which are functions that derive new state from existing state. Class Model views mimic `mobx-state-tree` views defined using the `.views()` API on models defined with `types.model`. See the [`mobx-state-tree` views docs](https://mobx-state-tree.js.org/concepts/views) for more information.
+
+To define a view on a Class Model, define a function that takes no arguments or a getter within a Class Model body, and register it as a view with `@view`.
+
+```typescript
+import { ClassModel, register, view } from "@gadgetinc/mobx-quick-tree";
+
+@register
+class Car extends ClassModel({
+  make: types.string,
+  model: types.string,
+  year: types.number,
+}) {
+  // define a view with a function and the @view decorator
+  @view
+  name() {
+    // refer to properties of the model with `this`
+    return `${this.year} ${this.model} ${this.make}`;
+  }
+}
+
+const car = Car.createReadOnly({ make: "Toyota", model: "Prius", year: 2008 });
+// run the view
+car.name(); // => "2008 Toyota Prius"
+```
+
+Views can be defined as functions which don't take arguments like above, or as getter properties on the class body:
+
+```typescript
+import { ClassModel, register, view } from "@gadgetinc/mobx-quick-tree";
+
+@register
+class Car extends ClassModel({
+  make: types.string,
+  model: types.string,
+  year: types.number,
+}) {
+  // define a view as a property with a getter and the @view decorator
+  @view
+  get name() {
+    // refer to properties of the model with `this`
+    return `${this.year} ${this.model} ${this.make}`;
+  }
+}
+
+const car = Car.createReadOnly({ make: "Toyota", model: "Prius", year: 2008 });
+// run the view
+car.name; // => "2008 Toyota Prius"
+```
+
+Views are available on both read-only and observable instances of Class Models.
+
+#### Defining actions with `@action`
+
+Class Models support actions on instances, which are functions that change state on the instance or it's children. Class Model actions are exactly the same as `mobx-state-tree` actions defined using the `.actions()` API on a `types.model`. See the [`mobx-state-tree` actions docs](https://mobx-state-tree.js.org/concepts/actions) for more information.
+
+To define an action on a Class Model, define a function within a Class Model body, and register it as an action with `@action`.
+
+```typescript
+import { ClassModel, register, action } from "@gadgetinc/mobx-quick-tree";
+
+@register
+class Car extends ClassModel({
+  make: types.string,
+  model: types.string,
+  year: types.number,
+}) {
+  // define an action with a function
+  @action
+  setModel(model: string) {
+    // set properties of the model on `this`
+    this.model = model;
+  }
+
+  // actions don't need to take arguments
+  @action
+  addYear() {
+    this.year = this.year + 1;
+  }
+}
+
+const car = Car.create({ make: "Toyota", model: "Prius", year: 2008 });
+car.year; // => 2008
+car.addYear(); // run the action
+car.year; // => 2009
+```
+
+Actions are only available on observable instances created with `.create`, and are present but will throw errors if created on instances created with `.createReadOnly`.
+
+##### Asynchronous actions / `flow`s
+
+`mobx-state-tree` allows defining asynchronous actions using the `flow` helper. Asynchronous actions can't use `async`/`await`, and instead must use generator functions so that `mobx-state-tree` can wrap each chunk of execution with the appropriate wrappers. For more information on the generator-based async actions in `mobx-state-tree`, see the [`mobx-state-tree` async actions docs](https://mobx-state-tree.js.org/concepts/async-actions).
+
+To define an asynchronous action in a class model, wrap your action generator function in the `flow()` helper, assign it to the name on the class, and apply the `@action` decorator like you might with synchronous actions.
+
+```typescript
+import { ClassModel, register, action } from "@gadgetinc/mobx-quick-tree";
+
+@register
+class Store extends ClassModel({
+  data: types.string,
+}) {
+  // define an async action with a generator function, the flow() helper, and the @action decorator
+  @action
+  load = flow(function* () {
+    // use `yield` like you might use `await` to run promises
+    this.data = yield getNewDataSomehow();
+  });
+}
+
+const store = Store.create({ data: "" });
+
+// call async actions with `await`
+await store.load();
+```
+
+Creating asynchronous actions using generators works as follow:
+
+- The action needs to be marked as generator, by postfixing the function keyword with a \* and a name (which will be used by middleware), and wrapping it with flow
+- The action can be paused by using a yield statement. Yield always needs to return a Promise.
+- If the promise resolves, the resolved value will be returned from the yield statement, and the action will continue to run
+- If the promise rejects, the action continues and the rejection reason will be thrown from the yield statement
+- Invoking the asynchronous action returns a promise. That will resolve with the return value of the function, or rejected with any exception that escapes from the asynchronous actions.
+
+#### Defining volatile properties with `@volatile`
+
+Class Models support volatile properties on instances, which are observable properties that are excluded from any snapshots. Volatiles last only for the lifetime of the object and are _not_ persisted because they aren't serialized into snapshots or read out of incoming snapshots. Class Model volatiles are exactly the same as `mobx-state-tree` volatiles defined using the `.volatile()` API on a `types.model`.
+
+Volatile tends to be most useful for implementation details, like timers, counters, transport objects like `fetch` requests, or other state that only matters for making other stuff work as opposed to saving source of truth data that might belong in a database. See the [`mobx-state-tree` volatile docs](https://mobx-state-tree.js.org/concepts/volatiles) for more information.
+
+Volatiles can be referred to and used in views, and changed by actions. Volatile properties are observable, so you can rely on views recomputing if they change for observable instances.
+
+To define an volatile property on a Class Model, define a type-only property within a Class Model body, and register it as a volatile `@volatile` that initializes the value:
+
+```typescript
+import { ClassModel, register, action } from "@gadgetinc/mobx-quick-tree";
+
+@register
+class Loader extends ClassModel({}) {
+  @volatile((_instance) => "ready");
+  state!: string;
+
+  @action
+  reload() {
+    self.state = "loading"
+    // ... do something else
+    self.state = "ready"
+  }
+}
+
+const car = Car.create({ make: "Toyota", model: "Prius", year: 2008 });
+car.reload();
+```
+
+Volatile properties are initialized using the initializer function passed to the `@volatile` decorator. The initializer is passed the instance being initialized, and must return a value to be set as the value of the property.
+
+Volatile properties are available on both read-only and observable instances. On read-only instances, volatiles will be initialized to the value returned by the initializer, and can't be changed after as actions are not available..
+
+#### References to and from class models
+
+Class Models support `types.references` within their properties as well as being the target of `types.reference`s on other models or class models.
+
+For example, a Class Model can references another Class Model in it's properties with `types.reference`:
+
+```typescript
+@register
+class Make extends ClassModel({
+  name: types.string,
+}) {}
+
+@register
+class Car extends ClassModel({
+  model: types.string,
+  make: types.reference(Make),
+}) {
+  @view
+  description() {
+    return `${this.make.name} ${this.name}`;
+  }
+}
+```
+
+A Class model can also reference a MST API model defined with `types.model`:
+
+```typescript
+const Make = types.model("Make", { name: types.string });
+
+@register
+class Car extends ClassModel({
+  model: types.string,
+  make: types.reference(Make),
+}) {
+  @view
+  description() {
+    return `${this.make.name} ${this.name}`;
+  }
+}
+```
+
+An MST API model defined with `types.model` can also reference a Class Model:
+
+```typescript
+@register
+class Make extends ClassModel({
+  name: types.string,
+}) {}
+
+const Car = types
+  .model({
+    model: types.string,
+    make: types.reference(Make),
+  })
+  .views((self) => ({
+    description() {
+      return `${self.make.name} ${self.name}`;
+    },
+  }));
+```
+
+#### Class model snapshots
+
+`mobx-state-tree` and `mobx-quick-tree` both support snapshotting the rich instances defined in JS land using the `getSnapshot` function, and both conform to the same set of rules. Snapshots are useful for persisting data from one place to another, and for later re-creating instances that match with `applySnapshot` or `.create`/`.createReadOnly`.
+
+Snapshots in `mobx-quick-tree` apply in the same way as `mobx-state-tree` in that they can be serialized without issue to JSON. Instances are turned into snapshots according to the following rules:
+
+- simple types like `types.boolean` or `types.string` are serialized as the equivalent JSON scalar type
+- `types.maybeNull` will output null in the snapshot if no value is present
+- `types.maybe` will be totally absent from the snapshot if no value is present
+- `types.array` arrays are serialized as plain JS arrays
+- `types.map` maps are turned into plain JS objects
+- properties defined on models are all serialized into the snapshot
+- actions, views, and volatiles on models will not be serialized at all into the snapshot
+- references will be serialized to the snapshot as the value of the referenced node's identifier (and not re-serialize the whole referenced node)
+
+#### Sharing functionality between class models
+
+When converting `types.model` models that use `types.compose`, you will need a deeper refactoring. `types.compose` is an implementation of multiple inheritance which ES6 classes don't support. There are a couple ways to re-use functionality in Class Models:
+
+- If the reusable chunk is only properties, you can define a constant of the properties, and spread it in the `ClassModel({...})` base class definition. For example:
+
+```typescript
+const SharedProps = {
+  name: types.string,
+  phoneNumber: types.string,
+};
+
+@register
+class Student extends ClassModel({
+  homeroom: types.string,
+  ...SharedProps,
+}) {}
+
+@register
+class Teacher extends ClassModel({
+  email: types.string,
+  ...SharedProps,
+}) {}
+```
+
+- If the reusable chunk is just logic like views and actions, you can use a function to subclass. For example:
+
+```javascript
+const addName = (klass) => {
+  return class extends klass {
+    @view
+    name() {
+      return this.firstName + " " + this.lastName;
+    }
+  };
+};
+
+@register
+class Student extends addName(
+  ClassModel({
+    firstName: types.string,
+    lastName: types.string,
+    homeroom: types.string,
+  })
+) {}
+
+@register
+class Teacher extends addName(
+  ClassModel({
+    firstName: types.string,
+    lastName: types.string,
+    email: types.string,
+  })
+) {}
+```
+
+If the reusable chunk includes both properties and views or actions, you can combine the two techniques.
+
+#### Converting a `types.model` to a Class Model
+
+Changing a `types.model` into a Class Model requires two key changes:
+
+- changing the syntax used to define the model
+- switching any `types.compose` calls to become subclasses, or spread properties in the `ClassModel` base class factory.
+
+##### Updating `types.model` syntax to become a `ClassModel`
+
+To convert a `types.model` into a Class Model, you need to update the definition to use a class body. Here are the conversion rules:
+
+- `types.model("Name", {...properties...})` becomes `class Name extends ClassModel({...properties...})`
+- the newly registered class needs to have the `@register` decorator
+- any views defined in `.views(...)` blocks become functions defined on the class decorated with the `@view` decorator
+- any actions defined in `.actions(...)` blocks become functions defined on the class decorated with the `@action` decorator, including `flow()` actions
+- any volatile properties defined in `.volatile()` blocks become one `@volatile` property in the class per property.
+
+For example, lets say we have this `types.model` model:
 
 ```typescript
 import { types } from "@gadgetinc/mobx-quick-tree";
 
-const MyAdder = types
-  .model({
-    left: types.number,
-    right: types.number,
+const Car = types
+  .model("Car", {
+    make: types.string,
+    model: types.string,
+    year: types.number,
   })
   .views((self) => ({
-    get sum() {
-      return self.left + self.right;
+    get name() {
+      return `${self.year} ${self.make} ${self.model}`;
+    },
+    sku() {
+      return `CAR-${self.year}-${self.model}`;
+    },
+  }))
+  .actions((self) => ({
+    setModel(model: string) {
+      self.model = model;
     },
   }));
+```
 
-// mobx-state-tree instance
-console.log(MyAdder.create({ left: 1, right: 2 }).sum);
+an equivalent Class Model would read:
 
-// mobx-quick-tree instance
-console.log(MyAdder.createReadOnly({ left: 1, right: 2 }).sum);
+```typescript
+import { types, register, action, view, ClassModel } from "@gadgetinc/mobx-quick-tree";
+
+@register
+class Car extends ClassModel({
+  make: types.string,
+  model: types.string,
+  year: types.number,
+}) {
+  @view
+  get name() {
+    return `${self.year} ${self.make} ${self.model}`;
+  }
+  @view
+  sku() {
+    return `CAR-${self.year}-${self.model}`;
+  }
+  @action
+  setModel(model: string) {
+    self.model = model;
+  }
+}
+```
+
+##### Updating `types.model` volatiles to become `ClassModel` volatiles
+
+In `types.model` models, [volatiles](https://mobx-state-tree.js.org/concepts/volatiles) are defined using the `.volatile()` call to add multiple properties, each with an initial value. In Class Models, volatiles are defined one at a time with the `@volatile` decorator.
+
+For example, with this `types.model` model:
+
+```typescript
+const Store = types.model("Store", {
+  data: types.string;
+}).volatile((self) => ({
+  state: "not-started",
+  finished: false
+})).actions(self => ({
+  load: flow(function *() {
+    self.state = "loading"
+    try {
+      self.data = yield loadSomeData();
+      self.state = "loaded";
+    } catch (error) {
+      self.state = "error;
+    } finally {
+      self.finished = true;
+    }
+  });
+}));
+```
+
+we convert each volatile property into a `@volatile` call on the class body:
+
+```typescript
+@register
+class Store extends ClassModel({
+  data: types.string;
+}) {
+  @volatile(() => "not-started")
+  state: string
+
+  @volatile(() => false)
+  finished: boolean
+
+  load = flow(function *() {
+    this.state = "loading"
+    try {
+      this.data = yield loadSomeData();
+      this.state = "loaded";
+    } catch (error) {
+      this.state = "error;
+    } finally {
+      this.finished = true;
+    }
+  });
+};
 ```

--- a/README.md
+++ b/README.md
@@ -453,11 +453,11 @@ const Car = types
 
 #### Dynamically defining Class Models using class expressions
 
-Usually, Class Models are defined using top level ES6 classes exported from from a file. For advanced use-cases, classes can also be built dynamically within functions using ES6 class expressions.
+Usually, Class Models are defined using top level ES6 classes exported from from a file. For advanced use-cases, classes can also be built dynamically within functions using ES6 class expressions. Generally, static classes defined with decorators are clearer and more performant, but for fancy class factories and the like you may want to use class expressions which MQT supports with slightly different syntax.
 
 To define a class using a class expression, you can no longer use the decorator based API suggested above, as in the latest version of TypeScript, decorators are not valid within class expressions. They work just fine in named classes, but not in dynamically defined classes that are passed around as values.
 
-Instead, you need to explicitly call the `register` function with the class and the list of decorators you'd like to apply to the class:
+Instead, you need to explicitly call the `register` function with the class, the list of decorators you'd like to apply to the class, and optionally a string class name:
 
 ```typescript
 // define an example function which returns a class model (a class factory)
@@ -474,10 +474,14 @@ const buildClass = () => {
     }
   };
 
-  return register(klass, {
-    someView: view,
-    someAction: action,
-  });
+  return register(
+    klass,
+    {
+      someView: view,
+      someAction: action,
+    },
+    "Example"
+  );
 };
 
 // invoke the class factory to define a class
@@ -689,7 +693,7 @@ const Store = types.model("Store", {
       self.data = yield loadSomeData();
       self.state = "loaded";
     } catch (error) {
-      self.state = "error;
+      self.state = "error";
     } finally {
       self.finished = true;
     }

--- a/bench/create-many-model-class.ts
+++ b/bench/create-many-model-class.ts
@@ -1,0 +1,6 @@
+import { TestClassModel } from "../spec/fixtures/TestClassModel";
+import { BigTestModelSnapshot } from "../spec/fixtures/TestModel";
+
+for (let x = 0; x < 50_000; ++x) {
+  TestClassModel.createReadOnly(BigTestModelSnapshot);
+}

--- a/bench/cross-framework.ts
+++ b/bench/cross-framework.ts
@@ -1,6 +1,6 @@
 import { Suite } from "benchmark";
-import { TestClassModel } from "../fixtures/TestClassModel";
-import { TestModel } from "../fixtures/TestModel";
+import { TestClassModel } from "../spec/fixtures/TestClassModel";
+import { TestModel } from "../spec/fixtures/TestModel";
 
 const suite = new Suite("instantiating same object with different paradigms");
 

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
     "lint": "yarn run lint:prettier && yarn run lint:eslint",
     "lint:prettier": "prettier --check \"{spec,src}/**/*.{js,ts}\"",
     "lint:eslint": "eslint --quiet --ext ts,tsx spec src",
-    "lint:fix": "eslint --ext ts --fix spec src; prettier --write --check \"{spec,src}/**/*.{js,ts}\"",
+    "lint:fix": "prettier --write --check \"{spec,src}/**/*.{js,ts}\"; eslint --ext ts --fix spec src",
     "build": "rm -rf dist && tsc",
     "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
     "prepublishOnly": "yarn run build",
     "prerelease": "gitpkg publish",
+    "clean": "rm -rf *.0x *-v8.log",
     "x": "ts-node --transpile-only"
   },
   "dependencies": {
@@ -40,6 +41,8 @@
     "@typescript-eslint/eslint-plugin": "^5.48.1",
     "@typescript-eslint/parser": "^5.0.0",
     "benchmark": "^2.1.4",
+    "conditional-type-checks": "^1.0.6",
+    "deep-freeze-es6": "^1.4.1",
     "eslint": "^8.28.0",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/spec/bench/create-many-model-class.ts
+++ b/spec/bench/create-many-model-class.ts
@@ -1,6 +1,0 @@
-import { TestClassModel } from "../fixtures/TestClassModel";
-import { BigTestModelSnapshot } from "../fixtures/TestModel";
-
-for (let x = 0; x < 50_000; ++x) {
-  TestClassModel.createReadOnly(BigTestModelSnapshot);
-}

--- a/spec/bench/create-many-model-class.ts
+++ b/spec/bench/create-many-model-class.ts
@@ -1,0 +1,6 @@
+import { TestClassModel } from "../fixtures/TestClassModel";
+import { BigTestModelSnapshot } from "../fixtures/TestModel";
+
+for (let x = 0; x < 50_000; ++x) {
+  TestClassModel.createReadOnly(BigTestModelSnapshot);
+}

--- a/spec/bench/cross-framework.ts
+++ b/spec/bench/cross-framework.ts
@@ -1,4 +1,5 @@
 import { Suite } from "benchmark";
+import { TestClassModel } from "../fixtures/TestClassModel";
 import { TestModel } from "../fixtures/TestModel";
 
 const suite = new Suite("instantiating same object with different paradigms");
@@ -26,6 +27,9 @@ suite
   })
   .add("mobx-quick-tree types.model", function () {
     TestModel.createReadOnly(TestModelSnapshot);
+  })
+  .add("mobx-quick-tree ClassModel", function () {
+    TestClassModel.createReadOnly(TestModelSnapshot);
   })
   .on("cycle", function (event: any) {
     console.log(String(event.target));

--- a/spec/class-model.spec.ts
+++ b/spec/class-model.spec.ts
@@ -1,7 +1,19 @@
 import type { Has, IsExact } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
-import type { IAnyType, IClassModelType, Instance, ISimpleType, IStateTreeNode, ModelPropertiesDeclaration, SnapshotIn } from "../src";
-import { flow, isReadOnlyNode, isStateTreeNode, types } from "../src";
+import {
+  flow,
+  getType,
+  IAnyType,
+  IClassModelType,
+  Instance,
+  ISimpleType,
+  isReadOnlyNode,
+  isStateTreeNode,
+  IStateTreeNode,
+  ModelPropertiesDeclaration,
+  SnapshotIn,
+  types,
+} from "../src";
 import { action, ClassModel, register, view, volatile } from "../src/class-model";
 import { $identifier } from "../src/symbols";
 import { NamedThingClass, TestClassModel } from "./fixtures/TestClassModel";
@@ -74,7 +86,8 @@ const DynamicNameExample = register(
     setNameAsync: action,
     volatileProp: volatile(() => "test"),
     setVolatileProp: action,
-  }
+  },
+  "NameExample"
 );
 
 @register
@@ -285,6 +298,12 @@ describe("class models", () => {
           }
 
           const _instance = create(ClassWithPropSyntax, { key: "1" }, readOnly);
+        });
+
+        test("instance type's name should be NameExample", () => {
+          const type = getType(record);
+          expect(type).toBeTruthy();
+          expect(type.name).toEqual("NameExample");
         });
       });
     });

--- a/spec/class-model.spec.ts
+++ b/spec/class-model.spec.ts
@@ -43,6 +43,44 @@ class NameExample extends ClassModel({ key: types.identifier, name: types.string
   }
 }
 
+const DynamicNameExample = register(
+  class extends ClassModel({ key: types.identifier, name: types.string }) {
+    setName(newName: string) {
+      this.name = newName;
+      return true;
+    }
+
+    slug() {
+      return this.name.toLowerCase().replace(/ /g, "-");
+    }
+
+    setNameAsync = flow(function* (this: NameExample, newName: string) {
+      yield Promise.resolve();
+      this.name = newName;
+      return true;
+    });
+
+    get nameLength() {
+      return this.name.length;
+    }
+
+    volatileProp!: string;
+
+    setVolatileProp(newProp: string) {
+      this.volatileProp = newProp;
+      return true;
+    }
+  },
+  {
+    setName: action,
+    slug: view,
+    setNameAsync: action,
+    nameLength: view,
+    volatileProp: volatile(() => "test"),
+    setVolatileProp: action,
+  }
+);
+
 @register
 class AutoIdentified extends ClassModel({ key: types.optional(types.identifier, () => "test") }) {
   @view
@@ -71,289 +109,294 @@ const ArrayOfModelClass = types.model("ArrayOfModelClass", {
 
 describe("class models", () => {
   describe.each([
-    ["read-only", true],
-    ["observable", false],
-  ])("%s", (_name, readOnly) => {
-    let record: NameExample;
-    beforeEach(() => {
-      record = create(NameExample, { key: "1", name: "Test" }, readOnly);
-    });
+    ["statically defined class model", NameExample],
+    ["dynamically defined class model", DynamicNameExample],
+  ])("%s", (_name, NameExample) => {
+    describe.each([
+      ["read-only", true],
+      ["observable", false],
+    ])("%s", (_name, readOnly) => {
+      let record: NameExample;
+      beforeEach(() => {
+        record = create(NameExample, { key: "1", name: "Test" }, readOnly);
+      });
 
-    it("should allow instantiating a new object", () => {
-      expect(record.name).toEqual("Test");
-    });
+      it("should allow instantiating a new object", () => {
+        expect(record.name).toEqual("Test");
+      });
 
-    it("separate instances should be independent", () => {
-      const newRecord = create(NameExample, { key: "2", name: "Test 2" }, readOnly);
-      expect(newRecord.name).toEqual("Test 2");
-      expect(record.name).toEqual("Test");
-    });
+      it("separate instances should be independent", () => {
+        const newRecord = create(NameExample, { key: "2", name: "Test 2" }, readOnly);
+        expect(newRecord.name).toEqual("Test 2");
+        expect(record.name).toEqual("Test");
+      });
 
-    it("should execute function views", () => {
-      expect(record.slug()).toEqual("test");
-    });
+      it("should execute function views", () => {
+        expect(record.slug()).toEqual("test");
+      });
 
-    it("should execute getter views", () => {
-      expect(record.nameLength).toEqual(4);
-    });
+      it("should execute getter views", () => {
+        expect(record.nameLength).toEqual(4);
+      });
 
-    it("should return volatile properties", () => {
-      expect(record.volatileProp).toEqual("test");
-    });
+      it("should return volatile properties", () => {
+        expect(record.volatileProp).toEqual("test");
+      });
 
-    it("can create an instance with an optional identifier prop", () => {
-      const auto = create(AutoIdentified, undefined, readOnly);
-      expect(auto.key).toEqual("test");
+      it("can create an instance with an optional identifier prop", () => {
+        const auto = create(AutoIdentified, undefined, readOnly);
+        expect(auto.key).toEqual("test");
 
-      const passed = create(AutoIdentified, { key: "passed" }, readOnly);
-      expect(passed.key).toEqual("passed");
-    });
+        const passed = create(AutoIdentified, { key: "passed" }, readOnly);
+        expect(passed.key).toEqual("passed");
+      });
 
-    test("actions should be present on the instance (but not necessarily callable)", () => {
-      expect("setName" in record).toBeTruthy();
-      expect("setVolatileProp" in record).toBeTruthy();
-    });
+      test("actions should be present on the instance (but not necessarily callable)", () => {
+        expect("setName" in record).toBeTruthy();
+        expect("setVolatileProp" in record).toBeTruthy();
+      });
 
-    test("async actions should be present on the instance (but not necessarily callable)", () => {
-      expect("setNameAsync" in record).toBeTruthy();
-    });
+      test("async actions should be present on the instance (but not necessarily callable)", () => {
+        expect("setNameAsync" in record).toBeTruthy();
+      });
 
-    test(".is returns true for instances of the class model", () => {
-      expect(NameExample.is(record)).toBeTruthy();
-      expect(TestClassModel.is(record)).toBeFalsy();
-    });
+      test(".is returns true for instances of the class model", () => {
+        expect(NameExample.is(record)).toBeTruthy();
+        expect(TestClassModel.is(record)).toBeFalsy();
+      });
 
-    describe("interop", () => {
-      test("it can create an instance of a model class owning an MQT node from a snapshot", () => {
-        const instance = create(
-          ParentOfMQT,
-          {
+      describe("interop", () => {
+        test("it can create an instance of a model class owning an MQT node from a snapshot", () => {
+          const instance = create(
+            ParentOfMQT,
+            {
+              key: "1",
+              thing: {
+                key: "child",
+                name: "hello",
+              },
+            },
+            readOnly
+          );
+
+          expect(instance.key).toEqual("1");
+          expect(instance.thing.key).toEqual("child");
+          expect(instance.thing.name).toEqual("hello");
+        });
+
+        test("it can create an instance of an MQT node owning a model class from a snapshot", () => {
+          const snapshot = {
             key: "1",
-            thing: {
+            child: {
               key: "child",
               name: "hello",
             },
-          },
-          readOnly
+          };
+          let instance;
+          if (readOnly) {
+            instance = create(ParentOfModelClass, snapshot, true);
+          } else {
+            instance = create(ParentOfModelClass, snapshot);
+          }
+
+          expect(instance.key).toEqual("1");
+          expect(instance.child.key).toEqual("child");
+          expect(instance.child.name).toEqual("hello");
+        });
+
+        test("it can create an instance of an MQT node owning a map of model classes from a snapshot", () => {
+          const snapshot = {
+            key: "1",
+            children: {
+              a: {
+                key: "a",
+                name: "hello",
+              },
+              b: {
+                key: "b",
+                name: "goodbye",
+              },
+            },
+          };
+
+          let instance;
+          if (readOnly) {
+            instance = create(MapOfModelClass, snapshot, true);
+          } else {
+            instance = create(MapOfModelClass, snapshot);
+          }
+
+          expect(instance.key).toEqual("1");
+          expect(instance.children.get("a")!.key).toEqual("a");
+          expect(instance.children.get("b")!.key).toEqual("b");
+        });
+
+        test("it can create an instance of an MQT node owning an array of model classes from a snapshot", () => {
+          const snapshot = {
+            key: "1",
+            children: [
+              {
+                key: "a",
+                name: "hello",
+              },
+              {
+                key: "b",
+                name: "goodbye",
+              },
+            ],
+          };
+
+          let instance;
+          if (readOnly) {
+            instance = create(ArrayOfModelClass, snapshot, true);
+          } else {
+            instance = create(ArrayOfModelClass, snapshot);
+          }
+
+          expect(instance.key).toEqual("1");
+          expect(instance.children[0].key).toEqual("a");
+          expect(instance.children[1].key).toEqual("b");
+        });
+
+        test("instances can be created of class models which use prop = syntax in the class body", () => {
+          @register
+          class ClassWithPropSyntax extends ClassModel({ key: types.identifier }) {
+            foo = "bar";
+          }
+
+          const _instance = create(ClassWithPropSyntax, { key: "1" }, readOnly);
+        });
+      });
+    });
+
+    describe("read only only behaviour", () => {
+      let record: NameExample;
+      beforeEach(() => {
+        record = create(NameExample, { key: "1", name: "Test" }, true);
+      });
+
+      test("running actions should throw because the instance is readonly", () => {
+        expect(() => record.setName("Test 2")).toThrowErrorMatchingInlineSnapshot(`"Can't run action "setName" for a readonly instance"`);
+      });
+
+      test("running async actions should throw because the instance is readonly", async () => {
+        await expect(async () => await record.setNameAsync("Test 2")).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Can't run flow action for a readonly instance"`
         );
-
-        expect(instance.key).toEqual("1");
-        expect(instance.thing.key).toEqual("child");
-        expect(instance.thing.name).toEqual("hello");
       });
 
-      test("it can create an instance of an MQT node owning a model class from a snapshot", () => {
-        const snapshot = {
-          key: "1",
-          child: {
-            key: "child",
-            name: "hello",
-          },
-        };
-        let instance;
-        if (readOnly) {
-          instance = create(ParentOfModelClass, snapshot, true);
-        } else {
-          instance = create(ParentOfModelClass, snapshot);
-        }
-
-        expect(instance.key).toEqual("1");
-        expect(instance.child.key).toEqual("child");
-        expect(instance.child.name).toEqual("hello");
-      });
-
-      test("it can create an instance of an MQT node owning a map of model classes from a snapshot", () => {
-        const snapshot = {
-          key: "1",
-          children: {
-            a: {
-              key: "a",
-              name: "hello",
-            },
-            b: {
-              key: "b",
-              name: "goodbye",
-            },
-          },
-        };
-
-        let instance;
-        if (readOnly) {
-          instance = create(MapOfModelClass, snapshot, true);
-        } else {
-          instance = create(MapOfModelClass, snapshot);
-        }
-
-        expect(instance.key).toEqual("1");
-        expect(instance.children.get("a")!.key).toEqual("a");
-        expect(instance.children.get("b")!.key).toEqual("b");
-      });
-
-      test("it can create an instance of an MQT node owning an array of model classes from a snapshot", () => {
-        const snapshot = {
-          key: "1",
-          children: [
-            {
-              key: "a",
-              name: "hello",
-            },
-            {
-              key: "b",
-              name: "goodbye",
-            },
-          ],
-        };
-
-        let instance;
-        if (readOnly) {
-          instance = create(ArrayOfModelClass, snapshot, true);
-        } else {
-          instance = create(ArrayOfModelClass, snapshot);
-        }
-
-        expect(instance.key).toEqual("1");
-        expect(instance.children[0].key).toEqual("a");
-        expect(instance.children[1].key).toEqual("b");
-      });
-
-      test("instances can be created of class models which use prop = syntax in the class body", () => {
+      it("can create an instance with an optional identifier at the $identifier private prop", () => {
         @register
-        class ClassWithPropSyntax extends ClassModel({ key: types.identifier }) {
-          foo = "bar";
-        }
+        class AutoIdentified extends ClassModel({ key: types.optional(types.identifier, () => "test") }) {}
 
-        const _instance = create(ClassWithPropSyntax, { key: "1" }, readOnly);
+        const auto = create(AutoIdentified, undefined, true);
+        expect((auto as any)[$identifier]).toEqual("test");
+
+        const passed = create(AutoIdentified, { key: "passed" }, true);
+        expect((passed as any)[$identifier]).toEqual("passed");
+      });
+
+      test("creating an instance with just a snapshot typechecks", () => {
+        create(NameExample, { key: "1", name: "Test" });
+        create(TestClassModel, TestModelSnapshot);
       });
     });
-  });
 
-  describe("read only only behaviour", () => {
-    let record: NameExample;
-    beforeEach(() => {
-      record = create(NameExample, { key: "1", name: "Test" }, true);
+    describe("observable only behaviour", () => {
+      let record: NameExample;
+      beforeEach(() => {
+        record = create(NameExample, { key: "1", name: "Test" }, false);
+      });
+
+      it("should allow executing actions", () => {
+        expect(record.name).toEqual("Test");
+
+        const actionResult = record.setName("New Name");
+        expect(actionResult).toBe(true);
+
+        expect(record.name).toEqual("New Name");
+      });
+
+      it("should allow executing flow actions", async () => {
+        expect(record.name).toEqual("Test");
+
+        const actionResult = await record.setNameAsync("New Name");
+        expect(actionResult).toBe(true);
+
+        expect(record.name).toEqual("New Name");
+      });
+
+      it("separate instances should be independent", () => {
+        expect(record.name).toEqual("Test");
+        const newRecord = create(NameExample, { key: "2", name: "Test 2" });
+        expect(newRecord).not.toBe(record);
+        expect(newRecord.name).toEqual("Test 2");
+        expect(record.name).toEqual("Test");
+
+        newRecord.setName("Test 3");
+        expect(record.name).toEqual("Test");
+        expect(newRecord.name).toEqual("Test 3");
+
+        record.setName("Test 4");
+        expect(record.name).toEqual("Test 4");
+        expect(newRecord.name).toEqual("Test 3");
+
+        const newNewRecord = create(NameExample, { key: "3", name: "Test 4" });
+        expect(newNewRecord).not.toBe(record);
+        expect(newNewRecord.name).toEqual("Test 4");
+        expect(record.name).toEqual("Test 4");
+
+        newNewRecord.setName("Test 5");
+        expect(newNewRecord.name).toEqual("Test 5");
+        expect(record.name).toEqual("Test 4");
+      });
+
+      it("should re-execute function views", () => {
+        expect(record.slug()).toEqual("test");
+        record.setName("New Name");
+        expect(record.slug()).toEqual("new-name");
+      });
+
+      it("should re-execute getter views", () => {
+        expect(record.nameLength).toEqual(4);
+        record.setName("New Name");
+        expect(record.nameLength).toEqual(8);
+      });
+
+      it("should allow executing volatile setters", () => {
+        expect(record.volatileProp).toEqual("test");
+
+        const actionResult = record.setVolatileProp("New prop");
+        expect(actionResult).toBe(true);
+
+        expect(record.volatileProp).toEqual("New prop");
+      });
     });
 
-    test("running actions should throw because the instance is readonly", () => {
-      expect(() => record.setName("Test 2")).toThrowErrorMatchingInlineSnapshot(`"Can't run action "setName" for a readonly instance"`);
-    });
+    describe("read-only class static constructor functions", () => {
+      test(".create() should return an observable instance", () => {
+        const record = NameExample.create({ key: "1", name: "Test" });
+        expect(isStateTreeNode(record)).toBe(true);
+        expect(isReadOnlyNode(record)).toBe(false);
 
-    test("running async actions should throw because the instance is readonly", async () => {
-      await expect(async () => await record.setNameAsync("Test 2")).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Can't run flow action for a readonly instance"`
-      );
-    });
+        expect(record.key).toEqual("1");
+        expect("setName" in record).toBe(true);
 
-    it("can create an instance with an optional identifier at the $identifier private prop", () => {
-      @register
-      class AutoIdentified extends ClassModel({ key: types.optional(types.identifier, () => "test") }) {}
+        // assert type returned from `create` includes not just properties but actions defined on the class
+        assert<Has<typeof record, { setName: (name: string) => boolean }>>(true);
+      });
 
-      const auto = create(AutoIdentified, undefined, true);
-      expect((auto as any)[$identifier]).toEqual("test");
+      test(".createReadOnly() should return a read only instance", () => {
+        const record = NameExample.createReadOnly({ key: "1", name: "Test" });
+        expect(isStateTreeNode(record)).toBe(true);
+        expect(isReadOnlyNode(record)).toBe(true);
 
-      const passed = create(AutoIdentified, { key: "passed" }, true);
-      expect((passed as any)[$identifier]).toEqual("passed");
-    });
+        expect(record.key).toEqual("1");
+        expect("setName" in record).toBe(true);
 
-    test("creating an instance with just a snapshot typechecks", () => {
-      create(NameExample, { key: "1", name: "Test" });
-      create(TestClassModel, TestModelSnapshot);
-    });
-  });
-
-  describe("observable only behaviour", () => {
-    let record: NameExample;
-    beforeEach(() => {
-      record = create(NameExample, { key: "1", name: "Test" }, false);
-    });
-
-    it("should allow executing actions", () => {
-      expect(record.name).toEqual("Test");
-
-      const actionResult = record.setName("New Name");
-      expect(actionResult).toBe(true);
-
-      expect(record.name).toEqual("New Name");
-    });
-
-    it("should allow executing flow actions", async () => {
-      expect(record.name).toEqual("Test");
-
-      const actionResult = await record.setNameAsync("New Name");
-      expect(actionResult).toBe(true);
-
-      expect(record.name).toEqual("New Name");
-    });
-
-    it("separate instances should be independent", () => {
-      expect(record.name).toEqual("Test");
-      const newRecord = create(NameExample, { key: "2", name: "Test 2" });
-      expect(newRecord).not.toBe(record);
-      expect(newRecord.name).toEqual("Test 2");
-      expect(record.name).toEqual("Test");
-
-      newRecord.setName("Test 3");
-      expect(record.name).toEqual("Test");
-      expect(newRecord.name).toEqual("Test 3");
-
-      record.setName("Test 4");
-      expect(record.name).toEqual("Test 4");
-      expect(newRecord.name).toEqual("Test 3");
-
-      const newNewRecord = create(NameExample, { key: "3", name: "Test 4" });
-      expect(newNewRecord).not.toBe(record);
-      expect(newNewRecord.name).toEqual("Test 4");
-      expect(record.name).toEqual("Test 4");
-
-      newNewRecord.setName("Test 5");
-      expect(newNewRecord.name).toEqual("Test 5");
-      expect(record.name).toEqual("Test 4");
-    });
-
-    it("should re-execute function views", () => {
-      expect(record.slug()).toEqual("test");
-      record.setName("New Name");
-      expect(record.slug()).toEqual("new-name");
-    });
-
-    it("should re-execute getter views", () => {
-      expect(record.nameLength).toEqual(4);
-      record.setName("New Name");
-      expect(record.nameLength).toEqual(8);
-    });
-
-    it("should allow executing volatile setters", () => {
-      expect(record.volatileProp).toEqual("test");
-
-      const actionResult = record.setVolatileProp("New prop");
-      expect(actionResult).toBe(true);
-
-      expect(record.volatileProp).toEqual("New prop");
-    });
-  });
-
-  describe("read-only class static constructor functions", () => {
-    test(".create() should return an observable instance", () => {
-      const record = NameExample.create({ key: "1", name: "Test" });
-      expect(isStateTreeNode(record)).toBe(true);
-      expect(isReadOnlyNode(record)).toBe(false);
-
-      expect(record.key).toEqual("1");
-      expect("setName" in record).toBe(true);
-
-      // assert type returned from `create` includes not just properties but actions defined on the class
-      assert<Has<typeof record, { setName: (name: string) => boolean }>>(true);
-    });
-
-    test(".createReadOnly() should return a read only instance", () => {
-      const record = NameExample.createReadOnly({ key: "1", name: "Test" });
-      expect(isStateTreeNode(record)).toBe(true);
-      expect(isReadOnlyNode(record)).toBe(true);
-
-      expect(record.key).toEqual("1");
-      expect("setName" in record).toBe(true);
-
-      // assert type returned from `create` includes not just properties but actions defined on the class
-      assert<Has<typeof record, { setName: (name: string) => boolean }>>(true);
+        // assert type returned from `create` includes not just properties but actions defined on the class
+        assert<Has<typeof record, { setName: (name: string) => boolean }>>(true);
+      });
     });
   });
 
@@ -499,5 +542,66 @@ describe("class models", () => {
     expect(() => {
       types.map(Unregistered);
     }).toThrow(/requires registration but has not been registered yet/);
+  });
+
+  describe("registering dynamically", () => {
+    const klass = class extends ClassModel({
+      key: types.string,
+    }) {
+      foo() {
+        return "bar";
+      }
+    };
+
+    test("tagging non-existent views throws an error", () => {
+      expect(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        register(klass, { doesntExist: view });
+      }).toThrow();
+    });
+
+    test("tagging non-existent actions throws an error", () => {
+      expect(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - this is a test
+        register(klass, { doesntExist: action });
+      }).toThrow();
+    });
+
+    test("set class factory example", () => {
+      const buildSet = <T extends IAnyType>(type: T) => {
+        const klass = class extends ClassModel({
+          items: types.array(type),
+        }) {
+          has(item: Instance<T>) {
+            return this.items.some((existing) => existing == item);
+          }
+
+          add(item: Instance<T>) {
+            if (!this.has(item)) {
+              this.items.push(item);
+            }
+          }
+
+          remove(item: Instance<T>) {
+            this.items.remove(item);
+          }
+        };
+
+        return register(klass, {
+          add: action,
+          remove: action,
+          has: view,
+        });
+      };
+
+      const NumberSet = buildSet(types.number);
+      const set = NumberSet.create();
+      set.add(1);
+      set.add(2);
+      expect(set.has(1)).toBeTruthy();
+      expect(set.has(3)).toBeFalsy();
+    });
   });
 });

--- a/spec/class-model.spec.ts
+++ b/spec/class-model.spec.ts
@@ -16,7 +16,6 @@ class NameExample extends ClassModel({ key: types.identifier, name: types.string
     return true;
   }
 
-  @view
   slug() {
     return this.name.toLowerCase().replace(/ /g, "-");
   }
@@ -28,7 +27,6 @@ class NameExample extends ClassModel({ key: types.identifier, name: types.string
     return true;
   });
 
-  @view
   get nameLength() {
     return this.name.length;
   }
@@ -73,9 +71,7 @@ const DynamicNameExample = register(
   },
   {
     setName: action,
-    slug: view,
     setNameAsync: action,
-    nameLength: view,
     volatileProp: volatile(() => "test"),
     setVolatileProp: action,
   }
@@ -83,7 +79,6 @@ const DynamicNameExample = register(
 
 @register
 class AutoIdentified extends ClassModel({ key: types.optional(types.identifier, () => "test") }) {
-  @view
   testKeyIsAlwaysSet() {
     assert<IsExact<typeof this.key, string>>(true);
   }
@@ -163,6 +158,31 @@ describe("class models", () => {
       test(".is returns true for instances of the class model", () => {
         expect(NameExample.is(record)).toBeTruthy();
         expect(TestClassModel.is(record)).toBeFalsy();
+      });
+
+      test("functions without an explicit @view decorator are available as views", () => {
+        @register
+        class Test extends ClassModel({ key: types.identifier }) {
+          foo() {
+            return this.key + "-foo";
+          }
+        }
+
+        const instance = create(Test, { key: "a" }, readOnly);
+        expect(instance.foo()).toEqual("a-foo");
+      });
+
+      test("functions with an explicit @view decorator are available as views", () => {
+        @register
+        class Test extends ClassModel({ key: types.identifier }) {
+          @view
+          foo() {
+            return this.key + "-foo";
+          }
+        }
+
+        const instance = create(Test, { key: "a" }, readOnly);
+        expect(instance.foo()).toEqual("a-foo");
       });
 
       describe("interop", () => {

--- a/spec/class-model.spec.ts
+++ b/spec/class-model.spec.ts
@@ -1,0 +1,503 @@
+import type { Has, IsExact } from "conditional-type-checks";
+import { assert } from "conditional-type-checks";
+import type { IAnyType, IClassModelType, Instance, ISimpleType, IStateTreeNode, ModelPropertiesDeclaration, SnapshotIn } from "../src";
+import { flow, isReadOnlyNode, isStateTreeNode, types } from "../src";
+import { action, ClassModel, register, view, volatile } from "../src/class-model";
+import { $identifier } from "../src/symbols";
+import { NamedThingClass, TestClassModel } from "./fixtures/TestClassModel";
+import { NamedThing, TestModelSnapshot } from "./fixtures/TestModel";
+import { create } from "./helpers";
+
+@register
+class NameExample extends ClassModel({ key: types.identifier, name: types.string }) {
+  @action
+  setName(newName: string) {
+    this.name = newName;
+    return true;
+  }
+
+  @view
+  slug() {
+    return this.name.toLowerCase().replace(/ /g, "-");
+  }
+
+  @action
+  setNameAsync = flow(function* (this: NameExample, newName: string) {
+    yield Promise.resolve();
+    this.name = newName;
+    return true;
+  });
+
+  @view
+  get nameLength() {
+    return this.name.length;
+  }
+
+  @volatile(() => "test")
+  volatileProp!: string;
+
+  @action
+  setVolatileProp(newProp: string) {
+    this.volatileProp = newProp;
+    return true;
+  }
+}
+
+@register
+class AutoIdentified extends ClassModel({ key: types.optional(types.identifier, () => "test") }) {
+  @view
+  testKeyIsAlwaysSet() {
+    assert<IsExact<typeof this.key, string>>(true);
+  }
+}
+
+@register
+class ParentOfMQT extends ClassModel({ key: types.identifier, thing: NamedThing }) {}
+
+const ParentOfModelClass = types.model("ParentOfModelClass", {
+  key: types.identifier,
+  child: NameExample,
+});
+
+const MapOfModelClass = types.model("MapOfModelClass", {
+  key: types.identifier,
+  children: types.map(NameExample),
+});
+
+const ArrayOfModelClass = types.model("ArrayOfModelClass", {
+  key: types.identifier,
+  children: types.array(NameExample),
+});
+
+describe("class models", () => {
+  describe.each([
+    ["read-only", true],
+    ["observable", false],
+  ])("%s", (_name, readOnly) => {
+    let record: NameExample;
+    beforeEach(() => {
+      record = create(NameExample, { key: "1", name: "Test" }, readOnly);
+    });
+
+    it("should allow instantiating a new object", () => {
+      expect(record.name).toEqual("Test");
+    });
+
+    it("separate instances should be independent", () => {
+      const newRecord = create(NameExample, { key: "2", name: "Test 2" }, readOnly);
+      expect(newRecord.name).toEqual("Test 2");
+      expect(record.name).toEqual("Test");
+    });
+
+    it("should execute function views", () => {
+      expect(record.slug()).toEqual("test");
+    });
+
+    it("should execute getter views", () => {
+      expect(record.nameLength).toEqual(4);
+    });
+
+    it("should return volatile properties", () => {
+      expect(record.volatileProp).toEqual("test");
+    });
+
+    it("can create an instance with an optional identifier prop", () => {
+      const auto = create(AutoIdentified, undefined, readOnly);
+      expect(auto.key).toEqual("test");
+
+      const passed = create(AutoIdentified, { key: "passed" }, readOnly);
+      expect(passed.key).toEqual("passed");
+    });
+
+    test("actions should be present on the instance (but not necessarily callable)", () => {
+      expect("setName" in record).toBeTruthy();
+      expect("setVolatileProp" in record).toBeTruthy();
+    });
+
+    test("async actions should be present on the instance (but not necessarily callable)", () => {
+      expect("setNameAsync" in record).toBeTruthy();
+    });
+
+    test(".is returns true for instances of the class model", () => {
+      expect(NameExample.is(record)).toBeTruthy();
+      expect(TestClassModel.is(record)).toBeFalsy();
+    });
+
+    describe("interop", () => {
+      test("it can create an instance of a model class owning an MQT node from a snapshot", () => {
+        const instance = create(
+          ParentOfMQT,
+          {
+            key: "1",
+            thing: {
+              key: "child",
+              name: "hello",
+            },
+          },
+          readOnly
+        );
+
+        expect(instance.key).toEqual("1");
+        expect(instance.thing.key).toEqual("child");
+        expect(instance.thing.name).toEqual("hello");
+      });
+
+      test("it can create an instance of an MQT node owning a model class from a snapshot", () => {
+        const snapshot = {
+          key: "1",
+          child: {
+            key: "child",
+            name: "hello",
+          },
+        };
+        let instance;
+        if (readOnly) {
+          instance = create(ParentOfModelClass, snapshot, true);
+        } else {
+          instance = create(ParentOfModelClass, snapshot);
+        }
+
+        expect(instance.key).toEqual("1");
+        expect(instance.child.key).toEqual("child");
+        expect(instance.child.name).toEqual("hello");
+      });
+
+      test("it can create an instance of an MQT node owning a map of model classes from a snapshot", () => {
+        const snapshot = {
+          key: "1",
+          children: {
+            a: {
+              key: "a",
+              name: "hello",
+            },
+            b: {
+              key: "b",
+              name: "goodbye",
+            },
+          },
+        };
+
+        let instance;
+        if (readOnly) {
+          instance = create(MapOfModelClass, snapshot, true);
+        } else {
+          instance = create(MapOfModelClass, snapshot);
+        }
+
+        expect(instance.key).toEqual("1");
+        expect(instance.children.get("a")!.key).toEqual("a");
+        expect(instance.children.get("b")!.key).toEqual("b");
+      });
+
+      test("it can create an instance of an MQT node owning an array of model classes from a snapshot", () => {
+        const snapshot = {
+          key: "1",
+          children: [
+            {
+              key: "a",
+              name: "hello",
+            },
+            {
+              key: "b",
+              name: "goodbye",
+            },
+          ],
+        };
+
+        let instance;
+        if (readOnly) {
+          instance = create(ArrayOfModelClass, snapshot, true);
+        } else {
+          instance = create(ArrayOfModelClass, snapshot);
+        }
+
+        expect(instance.key).toEqual("1");
+        expect(instance.children[0].key).toEqual("a");
+        expect(instance.children[1].key).toEqual("b");
+      });
+
+      test("instances can be created of class models which use prop = syntax in the class body", () => {
+        @register
+        class ClassWithPropSyntax extends ClassModel({ key: types.identifier }) {
+          foo = "bar";
+        }
+
+        const _instance = create(ClassWithPropSyntax, { key: "1" }, readOnly);
+      });
+    });
+  });
+
+  describe("read only only behaviour", () => {
+    let record: NameExample;
+    beforeEach(() => {
+      record = create(NameExample, { key: "1", name: "Test" }, true);
+    });
+
+    test("running actions should throw because the instance is readonly", () => {
+      expect(() => record.setName("Test 2")).toThrowErrorMatchingInlineSnapshot(`"Can't run action "setName" for a readonly instance"`);
+    });
+
+    test("running async actions should throw because the instance is readonly", async () => {
+      await expect(async () => await record.setNameAsync("Test 2")).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Can't run flow action for a readonly instance"`
+      );
+    });
+
+    it("can create an instance with an optional identifier at the $identifier private prop", () => {
+      @register
+      class AutoIdentified extends ClassModel({ key: types.optional(types.identifier, () => "test") }) {}
+
+      const auto = create(AutoIdentified, undefined, true);
+      expect((auto as any)[$identifier]).toEqual("test");
+
+      const passed = create(AutoIdentified, { key: "passed" }, true);
+      expect((passed as any)[$identifier]).toEqual("passed");
+    });
+
+    test("creating an instance with just a snapshot typechecks", () => {
+      create(NameExample, { key: "1", name: "Test" });
+      create(TestClassModel, TestModelSnapshot);
+    });
+  });
+
+  describe("observable only behaviour", () => {
+    let record: NameExample;
+    beforeEach(() => {
+      record = create(NameExample, { key: "1", name: "Test" }, false);
+    });
+
+    it("should allow executing actions", () => {
+      expect(record.name).toEqual("Test");
+
+      const actionResult = record.setName("New Name");
+      expect(actionResult).toBe(true);
+
+      expect(record.name).toEqual("New Name");
+    });
+
+    it("should allow executing flow actions", async () => {
+      expect(record.name).toEqual("Test");
+
+      const actionResult = await record.setNameAsync("New Name");
+      expect(actionResult).toBe(true);
+
+      expect(record.name).toEqual("New Name");
+    });
+
+    it("separate instances should be independent", () => {
+      expect(record.name).toEqual("Test");
+      const newRecord = create(NameExample, { key: "2", name: "Test 2" });
+      expect(newRecord).not.toBe(record);
+      expect(newRecord.name).toEqual("Test 2");
+      expect(record.name).toEqual("Test");
+
+      newRecord.setName("Test 3");
+      expect(record.name).toEqual("Test");
+      expect(newRecord.name).toEqual("Test 3");
+
+      record.setName("Test 4");
+      expect(record.name).toEqual("Test 4");
+      expect(newRecord.name).toEqual("Test 3");
+
+      const newNewRecord = create(NameExample, { key: "3", name: "Test 4" });
+      expect(newNewRecord).not.toBe(record);
+      expect(newNewRecord.name).toEqual("Test 4");
+      expect(record.name).toEqual("Test 4");
+
+      newNewRecord.setName("Test 5");
+      expect(newNewRecord.name).toEqual("Test 5");
+      expect(record.name).toEqual("Test 4");
+    });
+
+    it("should re-execute function views", () => {
+      expect(record.slug()).toEqual("test");
+      record.setName("New Name");
+      expect(record.slug()).toEqual("new-name");
+    });
+
+    it("should re-execute getter views", () => {
+      expect(record.nameLength).toEqual(4);
+      record.setName("New Name");
+      expect(record.nameLength).toEqual(8);
+    });
+
+    it("should allow executing volatile setters", () => {
+      expect(record.volatileProp).toEqual("test");
+
+      const actionResult = record.setVolatileProp("New prop");
+      expect(actionResult).toBe(true);
+
+      expect(record.volatileProp).toEqual("New prop");
+    });
+  });
+
+  describe("read-only class static constructor functions", () => {
+    test(".create() should return an observable instance", () => {
+      const record = NameExample.create({ key: "1", name: "Test" });
+      expect(isStateTreeNode(record)).toBe(true);
+      expect(isReadOnlyNode(record)).toBe(false);
+
+      expect(record.key).toEqual("1");
+      expect("setName" in record).toBe(true);
+
+      // assert type returned from `create` includes not just properties but actions defined on the class
+      assert<Has<typeof record, { setName: (name: string) => boolean }>>(true);
+    });
+
+    test(".createReadOnly() should return a read only instance", () => {
+      const record = NameExample.createReadOnly({ key: "1", name: "Test" });
+      expect(isStateTreeNode(record)).toBe(true);
+      expect(isReadOnlyNode(record)).toBe(true);
+
+      expect(record.key).toEqual("1");
+      expect("setName" in record).toBe(true);
+
+      // assert type returned from `create` includes not just properties but actions defined on the class
+      assert<Has<typeof record, { setName: (name: string) => boolean }>>(true);
+    });
+  });
+
+  test("class model classes are IClassModelType", () => {
+    const _testA: IClassModelType<{ key: ISimpleType<string>; name: ISimpleType<string> }> = NameExample;
+    const _testB: IClassModelType<{ key: ISimpleType<string>; name: ISimpleType<string> }> = NamedThingClass;
+  });
+
+  test("class model classes are IAnyTypes", () => {
+    const _testA: IAnyType = NameExample;
+    const _testB: IAnyType = NamedThingClass;
+    const _testC: IAnyType = TestClassModel;
+  });
+
+  test("class model records have typed properties for their props", () => {
+    assert<
+      Has<
+        TestClassModel,
+        {
+          bool: boolean;
+          optional: string;
+          frozen: { test: "string" };
+          notBool: boolean;
+        }
+      >
+    >(true);
+  });
+
+  test("class model records keep typed properties for their views and actions", () => {
+    assert<
+      Has<
+        TestClassModel,
+        {
+          arrayLength: number;
+          setB(v: boolean): void;
+        }
+      >
+    >(true);
+  });
+
+  test("nested class model records have typed properties for their props", () => {
+    const record = create(TestClassModel, TestModelSnapshot, true);
+    assert<
+      Has<
+        typeof record.nested,
+        {
+          key: string;
+          name: string;
+        }
+      >
+    >(true);
+  });
+
+  test("nested class model records keep typed properties for their views and actions", () => {
+    const record = create(TestClassModel, TestModelSnapshot, true);
+    record.nested.lowerCasedName();
+    assert<
+      Has<
+        typeof record.nested,
+        {
+          lowerCasedName(): string;
+          upperCasedName(): string;
+        }
+      >
+    >(true);
+  });
+
+  test("Instance type helper from MST returns just plain ole the class model type", () => {
+    const record = create(NameExample, { key: "1", name: "Test" }, true);
+    assert<IsExact<Instance<NameExample>, typeof record>>(true);
+  });
+
+  test("class model classes extend IAnyType", () => {
+    assert<typeof TestClassModel extends IAnyType ? true : false>(true);
+  });
+
+  test("class model instances are IStateTreeNodes", () => {
+    const _record: IStateTreeNode<IAnyType> = create(NameExample, { key: "1", name: "Test" }, true);
+  });
+
+  test("SnapshotIn type doesn't require optional properties", () => {
+    const _snapshot: SnapshotIn<typeof TestClassModel> = {
+      bool: true,
+      frozen: { test: "string" },
+      nested: { key: "a", name: "Apple" },
+    };
+  });
+
+  test("SnapshotIn type accepts JSON form of complex properties", () => {
+    const _snapshot: SnapshotIn<typeof TestClassModel> = {
+      bool: true,
+      frozen: { test: "string" },
+      nested: { key: "a", name: "Apple" },
+      map: {
+        b: { key: "b", name: "Banana" },
+        c: { key: "c", name: "Cherry" },
+      },
+      array: [{ key: "d", name: "Durian" }],
+    };
+  });
+
+  test("it can be used within a wrapping class factory", () => {
+    const identifiedClass = <P extends ModelPropertiesDeclaration = {}>(props: P) => {
+      return ClassModel({
+        key: types.identifier,
+        ...props,
+      });
+    };
+
+    @register
+    class Example extends identifiedClass({ name: types.string, number: types.number }) {}
+
+    const record = create(Example, { key: "1", name: "Test", number: 10 }, true);
+    expect(record.key).toEqual("1");
+    expect(record.name).toEqual("Test");
+    expect(record.number).toEqual(10);
+    assert<IsExact<typeof record.key, string>>(true);
+    assert<IsExact<typeof record.name, string>>(true);
+    assert<IsExact<typeof record.number, number>>(true);
+  });
+
+  test("unregistered types throw an error when being used in maps", () => {
+    class Unregistered extends ClassModel({ name: types.string }) {}
+
+    expect(() => {
+      types.map(Unregistered);
+    }).toThrow(/requires registration but has not been registered yet/);
+  });
+
+  test("unregistered types throw an error when being used in model properties", () => {
+    class Unregistered extends ClassModel({ name: types.string }) {}
+
+    expect(() => {
+      types.model({
+        prop: Unregistered,
+      });
+    }).toThrow(/requires registration but has not been registered yet/);
+  });
+
+  test("unextended class models count as unregistered", () => {
+    const Unregistered = ClassModel({ name: types.string });
+
+    expect(() => {
+      types.map(Unregistered);
+    }).toThrow(/requires registration but has not been registered yet/);
+  });
+});

--- a/spec/fixtures/TestClassModel.ts
+++ b/spec/fixtures/TestClassModel.ts
@@ -1,0 +1,46 @@
+import { types } from "../../src";
+import { action, ClassModel, register, view, volatile } from "../../src/class-model";
+
+@register
+export class NamedThingClass extends ClassModel({
+  key: types.identifier,
+  name: types.string,
+}) {
+  @view
+  lowerCasedName() {
+    return this.name.toLowerCase();
+  }
+
+  @view
+  upperCasedName() {
+    return this.name.toUpperCase();
+  }
+}
+
+@register
+export class TestClassModel extends ClassModel({
+  bool: types.boolean,
+  frozen: types.frozen<{ test: "string" }>(),
+  nested: NamedThingClass,
+  array: types.array(NamedThingClass),
+  map: types.map(types.late(() => NamedThingClass)),
+  optional: "value",
+}) {
+  @view
+  get notBool() {
+    return !this.bool;
+  }
+
+  @view
+  get arrayLength(): number {
+    return this.array.length;
+  }
+
+  @action
+  setB(v: boolean) {
+    this.bool = v;
+  }
+
+  @volatile(() => "test")
+  volatile!: string;
+}

--- a/spec/fixtures/TestClassModel.ts
+++ b/spec/fixtures/TestClassModel.ts
@@ -1,17 +1,15 @@
 import { types } from "../../src";
-import { action, ClassModel, register, view, volatile } from "../../src/class-model";
+import { action, ClassModel, register, volatile } from "../../src/class-model";
 
 @register
 export class NamedThingClass extends ClassModel({
   key: types.identifier,
   name: types.string,
 }) {
-  @view
   lowerCasedName() {
     return this.name.toLowerCase();
   }
 
-  @view
   upperCasedName() {
     return this.name.toUpperCase();
   }
@@ -26,12 +24,10 @@ export class TestClassModel extends ClassModel({
   map: types.map(types.late(() => NamedThingClass)),
   optional: "value",
 }) {
-  @view
   get notBool() {
     return !this.bool;
   }
 
-  @view
   get arrayLength(): number {
     return this.array.length;
   }

--- a/spec/fixtures/TestModel.ts
+++ b/spec/fixtures/TestModel.ts
@@ -1,8 +1,10 @@
+import deepFreeze from "deep-freeze-es6";
 import type { SnapshotIn } from "../../src";
+
 import { types } from "../../src";
 
 export const NamedThing = types
-  .model("BooleanWrapper", {
+  .model("NamedThing", {
     key: types.identifier,
     name: types.string,
   })
@@ -40,7 +42,7 @@ export const TestModel = types
     },
   }));
 
-export const TestModelSnapshot: SnapshotIn<typeof TestModel> = {
+export const TestModelSnapshot: SnapshotIn<typeof TestModel> = deepFreeze({
   bool: true,
   frozen: { test: "string" },
   nested: {
@@ -53,4 +55,33 @@ export const TestModelSnapshot: SnapshotIn<typeof TestModel> = {
       name: "Testy McTest",
     },
   },
-};
+  array: [
+    {
+      key: "other_key",
+      name: "A test array element",
+    },
+  ],
+});
+
+export const BigTestModelSnapshot: SnapshotIn<typeof TestModel> = deepFreeze({
+  bool: true,
+  frozen: { test: "string" },
+  nested: {
+    key: "mixed_up",
+    name: "MiXeD CaSe",
+  },
+  array: [
+    { key: "1", name: "Array Item 1" },
+    { key: "2", name: "Array Item 2" },
+    { key: "3", name: "Array Item 3" },
+    { key: "4", name: "Array Item 4" },
+    { key: "5", name: "Array Item 4" },
+  ],
+  map: {
+    a: { key: "a", name: "Map Item A" },
+    b: { key: "b", name: "Map Item B" },
+    c: { key: "c", name: "Map Item C" },
+    d: { key: "e", name: "Map Item E" },
+    f: { key: "f", name: "Map Item F" },
+  },
+});

--- a/spec/helpers.ts
+++ b/spec/helpers.ts
@@ -1,0 +1,10 @@
+import type { IAnyType, Instance, SnapshotIn } from "../src";
+
+/** Easily reate an observable or readonly instance of a type */
+export const create = <T extends IAnyType>(type: T, snapshot?: SnapshotIn<T>, readOnly = false): Instance<T> => {
+  if (readOnly) {
+    return type.createReadOnly(snapshot);
+  } else {
+    return type.create(snapshot);
+  }
+};

--- a/spec/model-class-reference.spec.ts
+++ b/spec/model-class-reference.spec.ts
@@ -1,0 +1,156 @@
+import { types } from "../src";
+import { action, ClassModel, register } from "../src/class-model";
+import { create } from "./helpers";
+
+@register
+class Referrable extends ClassModel({
+  key: types.identifier,
+  count: types.number,
+}) {}
+
+@register
+class Referencer extends ClassModel({
+  ref: types.reference(Referrable),
+  safeRef: types.safeReference(Referrable),
+}) {
+  @action
+  setRef(ref: Referrable) {
+    // Just here for typechecking
+    this.ref = ref;
+  }
+}
+
+@register
+class Root extends ClassModel({
+  model: Referencer,
+  refs: types.array(Referrable),
+}) {}
+
+describe("model class references", () => {
+  test("can resolve valid references", () => {
+    const root = create(
+      Root,
+      {
+        model: {
+          ref: "item-a",
+        },
+        refs: [
+          { key: "item-a", count: 12 },
+          { key: "item-b", count: 523 },
+        ],
+      },
+      true
+    );
+
+    expect(root.model.ref).toEqual(
+      expect.objectContaining({
+        key: "item-a",
+        count: 12,
+      })
+    );
+  });
+
+  test("throws for invalid refs", () => {
+    const createRoot = () =>
+      create(
+        Root,
+        {
+          model: {
+            ref: "item-c",
+          },
+          refs: [
+            { key: "item-a", count: 12 },
+            { key: "item-b", count: 523 },
+          ],
+        },
+        true
+      );
+
+    expect(createRoot).toThrow();
+  });
+
+  test("can resolve valid safe references", () => {
+    const root = create(
+      Root,
+      {
+        model: {
+          ref: "item-a",
+          safeRef: "item-b",
+        },
+        refs: [
+          { key: "item-a", count: 12 },
+          { key: "item-b", count: 523 },
+        ],
+      },
+      true
+    );
+
+    expect(root.model.safeRef).toEqual(
+      expect.objectContaining({
+        key: "item-b",
+        count: 523,
+      })
+    );
+  });
+
+  test("does not throw for invalid safe references", () => {
+    const root = create(
+      Root,
+      {
+        model: {
+          ref: "item-a",
+          safeRef: "item-c",
+        },
+        refs: [
+          { key: "item-a", count: 12 },
+          { key: "item-b", count: 523 },
+        ],
+      },
+      true
+    );
+
+    expect(root.model.safeRef).toBeUndefined();
+  });
+
+  test("references are equal to the instances they refer to", () => {
+    const root = create(
+      Root,
+      {
+        model: {
+          ref: "item-a",
+          safeRef: "item-b",
+        },
+        refs: [
+          { key: "item-a", count: 12 },
+          { key: "item-b", count: 523 },
+        ],
+      },
+      true
+    );
+
+    expect(root.model.ref).toBe(root.refs[0]);
+    expect(root.model.ref).toEqual(root.refs[0]);
+    expect(root.model.ref).toStrictEqual(root.refs[0]);
+  });
+
+  test("safe references are equal to the instances they refer to", () => {
+    const root = create(
+      Root,
+      {
+        model: {
+          ref: "item-a",
+          safeRef: "item-b",
+        },
+        refs: [
+          { key: "item-a", count: 12 },
+          { key: "item-b", count: 523 },
+        ],
+      },
+      true
+    );
+
+    expect(root.model.safeRef).toBe(root.refs[1]);
+    expect(root.model.safeRef).toEqual(root.refs[1]);
+    expect(root.model.safeRef).toStrictEqual(root.refs[1]);
+  });
+});

--- a/spec/types.spec.ts
+++ b/spec/types.spec.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/consistent-type-imports */
+import type { IsExact } from "conditional-type-checks";
+import { assert } from "conditional-type-checks";
+import type { TypesForModelPropsDeclaration } from "../src";
+import { IMaybeNullType, INodeModelType, IOptionalType, ISimpleType, types } from "../src";
+import { NamedThingClass } from "./fixtures/TestClassModel";
+import { NamedThing } from "./fixtures/TestModel";
+
+describe("type helper unit type tests", () => {
+  test("TypesForModelPropsDeclaration converts model prop declarations to uniform ITypes", () => {
+    const declaration = {
+      str: types.string,
+      literal: "foobar",
+      num: types.number,
+      opt: types.optional(types.string, "hello"),
+      nullable: types.maybeNull(types.string),
+      model: NamedThing,
+      modelClass: NamedThingClass,
+    };
+
+    type Actual = TypesForModelPropsDeclaration<typeof declaration>;
+    type Expected = {
+      str: ISimpleType<string>;
+      literal: IOptionalType<ISimpleType<string>, [undefined]>;
+      num: ISimpleType<number>;
+      opt: IOptionalType<ISimpleType<string>, [undefined]>;
+      nullable: IMaybeNullType<ISimpleType<string>>;
+      model: INodeModelType<
+        {
+          key: ISimpleType<string>;
+          name: ISimpleType<string>;
+        },
+        { lowerCasedName(): string; upperCasedName(): string }
+      >;
+      modelClass: typeof NamedThingClass;
+    };
+
+    assert<IsExact<Actual, Expected>>(true);
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -188,7 +188,7 @@ export const isRoot = (value: IAnyStateTreeNode): boolean => {
     return mstIsRoot(value);
   }
 
-  return value[$parent] === undefined;
+  return !value[$parent];
 };
 
 export function resolveIdentifier<T extends IAnyModelType>(
@@ -267,9 +267,10 @@ export function cast(snapshotOrInstance: any): any {
 }
 
 /**
- * Defines a new asynchronous action that uses `yield` instead of `await` for waiting for the results of promises
+ * Defines a new asynchronous action. `mobx-quick-tree` (and `mobx-state-tree`) require this wrapper around asynchronous actions, and require those action functions to be generators using `yield` instead of `await`.
  *
  * Accepts an incoming generator function and returns a new async function with the right mobx-state-tree wrapping.
+ * See https://mobx-state-tree.js.org/concepts/async-actions for more info.
  */
 export function flow<R, Args extends any[], This = unknown>(
   generator: (this: This, ...args: Args) => Generator<PromiseLike<any>, R, any>

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,9 +1,10 @@
 import { isStateTreeNode, types } from "mobx-state-tree";
 import { BaseType, setParent, setType } from "./base";
-import { $type } from "./symbols";
+import { ensureRegistered } from "./class-model";
+import { $readOnly, $type } from "./symbols";
 import type { IAnyStateTreeNode, IAnyType, IArrayType, IMSTArray, Instance, InstantiateContext } from "./types";
 
-export class QuickArray<T extends IAnyType> extends Array<T["InstanceType"]> implements IMSTArray<T> {
+export class QuickArray<T extends IAnyType> extends Array<Instance<T>> implements IMSTArray<T> {
   static get [Symbol.species]() {
     return Array;
   }
@@ -12,6 +13,10 @@ export class QuickArray<T extends IAnyType> extends Array<T["InstanceType"]> imp
 
   get [Symbol.toStringTag]() {
     return "Array" as const;
+  }
+
+  get [$readOnly]() {
+    return true;
   }
 
   spliceWithArray(_index: number, _deleteCount?: number, _newItems?: Instance<T>[]): Instance<T>[] {
@@ -78,5 +83,6 @@ class ArrayType<T extends IAnyType> extends BaseType<Array<T["InputType"]> | und
 }
 
 export const array = <T extends IAnyType>(childrenType: T): IArrayType<T> => {
+  ensureRegistered(childrenType);
   return new ArrayType(childrenType);
 };

--- a/src/base.ts
+++ b/src/base.ts
@@ -24,6 +24,9 @@ export abstract class BaseType<InputType, OutputType, InstanceType> {
     });
   }
 
+  /**
+   * @deprecated Prefer the top level `create` function instead
+   */
   create(snapshot?: this["InputType"], env?: any): this["InstanceType"] {
     return this.mstType.create(snapshot, env);
   }
@@ -31,6 +34,9 @@ export abstract class BaseType<InputType, OutputType, InstanceType> {
   abstract is(value: IAnyStateTreeNode): value is this["InstanceType"];
   abstract is(value: any): value is this["InputType"] | this["InstanceType"];
 
+  /**
+   * @deprecated Prefer the top level `create` function instead
+   */
   createReadOnly(snapshot?: InputType, env?: any): this["InstanceType"] {
     const context: InstantiateContext = {
       referenceCache: new Map(),
@@ -43,15 +49,7 @@ export abstract class BaseType<InputType, OutputType, InstanceType> {
       resolver();
     }
 
-    const maybeObjectInstance: unknown = instance;
-    if (typeof maybeObjectInstance === "object" && maybeObjectInstance !== null) {
-      Reflect.defineProperty(maybeObjectInstance, $env, {
-        value: env,
-        configurable: false,
-        enumerable: false,
-        writable: false,
-      });
-    }
+    setEnv(instance, env);
 
     return instance;
   }
@@ -76,6 +74,18 @@ export const setParent = (value: unknown, parent: any) => {
   if (value && typeof value == "object") {
     Reflect.defineProperty(value, $parent, {
       value: parent,
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    });
+  }
+};
+
+/** @hidden */
+export const setEnv = (instance: unknown, env: any) => {
+  if (typeof instance === "object" && instance !== null) {
+    Reflect.defineProperty(instance, $env, {
+      value: env,
       configurable: false,
       enumerable: false,
       writable: false,

--- a/src/base.ts
+++ b/src/base.ts
@@ -25,7 +25,7 @@ export abstract class BaseType<InputType, OutputType, InstanceType> {
   }
 
   /**
-   * @deprecated Prefer the top level `create` function instead
+   * Create a new instance of this class model in observable mode. Uses an `mobx-state-tree` type under the hood.
    */
   create(snapshot?: this["InputType"], env?: any): this["InstanceType"] {
     return this.mstType.create(snapshot, env);
@@ -35,7 +35,7 @@ export abstract class BaseType<InputType, OutputType, InstanceType> {
   abstract is(value: any): value is this["InputType"] | this["InstanceType"];
 
   /**
-   * @deprecated Prefer the top level `create` function instead
+   * Create a new instance of this class model in readonly mode. Properties and views are accessible on readonly instances but actions will throw if run.
    */
   createReadOnly(snapshot?: InputType, env?: any): this["InstanceType"] {
     const context: InstantiateContext = {

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -1,0 +1,265 @@
+import type { IModelType as MSTIModelType, ModelActions } from "mobx-state-tree";
+import { types as mstTypes } from "mobx-state-tree";
+import "reflect-metadata";
+import { defaultThrowAction, instantiateInstanceFromProperties, mstPropsFromQuickProps, propsFromModelPropsDeclaration } from "./model";
+import { $env, $readOnly, $registered, $requiresRegistration, $type } from "./symbols";
+import type {
+  IAnyType,
+  IClassModelType,
+  InputsForModel,
+  InputTypesForModelProps,
+  InstantiateContext,
+  ModelPropertiesDeclaration,
+  ModelViews,
+  TypesForModelPropsDeclaration,
+} from "./types";
+
+type ActionMetadata = {
+  type: "action";
+  property: string;
+  described: boolean;
+};
+
+type ViewMetadata = {
+  type: "view";
+  property: string;
+};
+
+export type VolatileMetadata = {
+  type: "volatile";
+  property: string;
+  initializer: VolatileInitializer<any>;
+};
+
+type VolatileInitializer<T> = (instance: T) => Record<string, any>;
+
+const metadataPrefix = "mqt:properties";
+const viewKeyPrefix = `${metadataPrefix}:view`;
+const actionKeyPrefix = `${metadataPrefix}:action`;
+const volatileKeyPrefix = `${metadataPrefix}:volatile`;
+
+/**
+ * Create a new base class for a ClassModel to extend. This is a function that you call that returns a class (a class factory).
+ *
+ * @example
+ *
+ * class MyModel extends ClassModel({ name: types.string }) {
+ *   @view
+ *   get upperCasedName() {
+ *     return this.name.toUpperCase();
+ *   }
+ *
+ *   @action
+ *   setName(name: string) {
+ *     this.name = name;
+ *   }
+ * }
+ */
+export const ClassModel = <PropsDeclaration extends ModelPropertiesDeclaration>(
+  propertiesDeclaration: PropsDeclaration
+): IClassModelType<TypesForModelPropsDeclaration<PropsDeclaration>> => {
+  const props = propsFromModelPropsDeclaration(propertiesDeclaration);
+  return class Base {
+    static isMQTClassModel = true as const;
+    static properties = props;
+    static mstType: MSTIModelType<any, any>;
+    static readonly [$requiresRegistration] = true;
+
+    readonly [$env]?: any;
+
+    constructor(
+      attrs?: InputsForModel<InputTypesForModelProps<TypesForModelPropsDeclaration<PropsDeclaration>>>,
+      env?: any,
+      context?: InstantiateContext,
+      /** @hidden */ hackyPreventInitialization = false
+    ) {
+      if (hackyPreventInitialization) {
+        return;
+      }
+
+      const klass = this.constructor as IClassModelType<any>;
+
+      const isRoot = !context;
+      context ??= {
+        referenceCache: new Map(),
+        referencesToResolve: [],
+        env,
+      };
+
+      this[$env] = env;
+      instantiateInstanceFromProperties(this, attrs, props, klass.mstType.identifierAttribute, context);
+      initializeVolatiles(this, this, klass.volatiles);
+
+      if (isRoot) {
+        for (const resolver of context.referencesToResolve) {
+          resolver();
+        }
+      }
+    }
+
+    get [$readOnly]() {
+      return true;
+    }
+
+    get [$type]() {
+      return this.constructor as IClassModelType<TypesForModelPropsDeclaration<PropsDeclaration>>;
+    }
+  } as any;
+};
+
+/**
+ * Class decorator for registering MQT class models as setup.
+ *
+ * @example
+ * ```
+ *   @register
+ *   class Example extends ClassModel({ name: types.string }) {
+ *     @view
+ *     get bigName() {
+ *       return this.name.toUpperCase();
+ *     }
+ *   }
+ * ```
+ */
+export function register<Klass extends { new (...args: any[]): {} }>(object: Klass) {
+  const klass = object as any as IClassModelType<any>;
+  const mstActions: ModelActions = {};
+  const mstViews: ModelViews = {};
+  const mstVolatiles: Record<string, VolatileMetadata> = {};
+
+  // list all keys defined at the prototype level to search for volatiles and actions
+  const metadataKeys = Reflect.getMetadataKeys(klass.prototype);
+  for (const metadataKey of metadataKeys.filter((key) => key.startsWith(metadataPrefix))) {
+    const metadata = Reflect.getMetadata(metadataKey, klass.prototype) as ActionMetadata | ViewMetadata | VolatileMetadata;
+    switch (metadata.type) {
+      case "view": {
+        Object.defineProperty(mstViews, metadata.property, {
+          ...Object.getOwnPropertyDescriptor(klass.prototype, metadata.property),
+          enumerable: true,
+        });
+        break;
+      }
+      case "action": {
+        let target: any;
+        if (metadata.described) {
+          target = klass.prototype;
+        } else {
+          // hackily instantiate the class to get at the instance level properties defined by the class body (those that aren't on the prototype)
+          target = new (klass as any)({}, undefined, undefined, true);
+        }
+        const descriptor = Object.getOwnPropertyDescriptor(target, metadata.property);
+
+        // add the action to the MST actions we'll add to the MST model type
+        Object.defineProperty(mstActions, metadata.property, {
+          ...descriptor,
+          enumerable: true,
+        });
+
+        // mark the action as not-runnable on the readonly class
+        Object.defineProperty(klass.prototype, metadata.property, {
+          ...descriptor,
+          enumerable: true,
+          value: defaultThrowAction(metadata.property),
+        });
+
+        break;
+      }
+      case "volatile": {
+        mstVolatiles[metadata.property] = metadata;
+      }
+    }
+  }
+
+  klass.volatiles = mstVolatiles;
+
+  // conform to the API that the other MQT types expect for creating instances
+  klass.instantiate = (snapshot, context) => new klass(snapshot, context.env, context);
+  (klass as any).is = (value: any) => value instanceof klass || klass.mstType.is(value);
+  klass.create = (snapshot, env) => klass.mstType.create(snapshot, env);
+  klass.createReadOnly = (snapshot, env) => new klass(snapshot, env) as any;
+
+  // create the MST type for not-readonly versions of this using the views and actions extracted from the class
+  klass.mstType = mstTypes
+    .model(klass.name, mstPropsFromQuickProps(klass.properties))
+    .views((self) => bindToSelf(self, mstViews))
+    .actions((self) => bindToSelf(self, mstActions));
+
+  if (Object.keys(mstVolatiles).length > 0) {
+    // define the volatile properties in one shot by running any passed initializers
+    (klass as any).mstType = (klass as any).mstType.volatile((self: any) => initializeVolatiles({}, self, mstVolatiles));
+  }
+
+  (klass as any)[$registered] = true;
+
+  return klass as any;
+}
+
+/**
+ * Function decorator for registering MST actions within MQT class models.
+ */
+export const action = (target: any, property: string, descriptor?: PropertyDescriptor) => {
+  const metadata: ActionMetadata = { type: "action", property, described: !!descriptor };
+  Reflect.defineMetadata(`${actionKeyPrefix}:${property}`, metadata, target);
+};
+
+/**
+ * Function decorator for registering MST views within MQT class models.
+ */
+export const view = (target: any, property: string, _descriptor: PropertyDescriptor) => {
+  const metadata: ViewMetadata = { type: "view", property };
+  Reflect.defineMetadata(`${viewKeyPrefix}:${property}`, metadata, target);
+};
+
+/**
+ * Function decorator for registering MST volatiles within MQT class models.
+ */
+export function volatile(initializer: (instance: any) => any) {
+  return (target: any, property: string) => {
+    const metadata: VolatileMetadata = { type: "volatile", property: property, initializer };
+    Reflect.defineMetadata(`${volatileKeyPrefix}:${property}`, metadata, target);
+  };
+}
+
+function bindToSelf<T extends Record<string, any>>(self: object, inputs: T): T {
+  const outputs = {} as T;
+  for (const [key, property] of Object.entries(Object.getOwnPropertyDescriptors(inputs))) {
+    if (typeof property.value === "function") {
+      property.value = property.value.bind(self);
+    }
+    if (typeof property.get === "function") {
+      property.get = property.get.bind(self);
+    }
+    if (typeof property.set === "function") {
+      property.set = property.set.bind(self);
+    }
+    Object.defineProperty(outputs, key, property);
+  }
+  return outputs;
+}
+
+/**
+ * Ensure a given type is registered if it requires registration.
+ * Throws an error if a type requires registration but has not been registered.
+ * @hidden
+ */
+export const ensureRegistered = (type: IAnyType) => {
+  let chain = type;
+  while (chain) {
+    if ((chain as any)[$requiresRegistration]) {
+      if (!(type as any)[$registered]) {
+        throw new Error(
+          `Type ${type.name} requires registration but has not been registered yet. Add the @register decorator to it for it to function correctly.`
+        );
+      }
+      break;
+    }
+    chain = Object.getPrototypeOf(chain);
+  }
+};
+
+function initializeVolatiles(result: Record<string, any>, node: Record<string, any>, volatiles: Record<string, VolatileMetadata>) {
+  for (const [key, metadata] of Object.entries(volatiles)) {
+    result[key] = metadata.initializer(node);
+  }
+  return result;
+}

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -3,7 +3,7 @@ import { types as mstTypes } from "mobx-state-tree";
 import "reflect-metadata";
 import { RegistrationError } from "./errors";
 import { defaultThrowAction, instantiateInstanceFromProperties, mstPropsFromQuickProps, propsFromModelPropsDeclaration } from "./model";
-import { $env, $readOnly, $registered, $requiresRegistration, $type, $volatileDefiner } from "./symbols";
+import { $env, $parent, $readOnly, $registered, $requiresRegistration, $type, $volatileDefiner } from "./symbols";
 import type {
   IAnyType,
   IClassModelType,
@@ -75,7 +75,10 @@ export const ClassModel = <PropsDeclaration extends ModelPropertiesDeclaration>(
     static mstType: MSTIModelType<any, any>;
     static readonly [$requiresRegistration] = true;
 
+    /** @hidden */
     readonly [$env]?: any;
+    /** @hidden */
+    readonly [$parent] = null;
 
     constructor(
       attrs?: InputsForModel<InputTypesForModelProps<TypesForModelPropsDeclaration<PropsDeclaration>>>,
@@ -130,7 +133,11 @@ export const ClassModel = <PropsDeclaration extends ModelPropertiesDeclaration>(
  *   }
  * ```
  */
-export function register<Instance, Klass extends { new (...args: any[]): Instance }>(object: Klass, tags?: RegistrationTags<Instance>) {
+export function register<Instance, Klass extends { new (...args: any[]): Instance }>(
+  object: Klass,
+  tags?: RegistrationTags<Instance>,
+  name?: string
+) {
   const klass = object as any as IClassModelType<any>;
   const mstActions: ModelActions = {};
   const mstViews: ModelViews = {};
@@ -196,6 +203,10 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
         mstVolatiles[metadata.property] = metadata;
       }
     }
+  }
+
+  if (name) {
+    Object.defineProperty(klass, "name", { value: name });
   }
 
   klass.volatiles = mstVolatiles;

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,29 +1,32 @@
 import { types as mstTypes } from "mobx-state-tree";
 import type { ModelInitializer } from "./model";
 import { ModelType } from "./model";
-import type { IAnyModelType, IModelType } from "./types";
+import type { IAnyNodeModelType, INodeModelType } from "./types";
 
-type PropsFromTypes<T> = T extends IModelType<infer P, any>
+type PropsFromTypes<T> = T extends INodeModelType<infer P, any>
   ? P
-  : T extends [IModelType<infer P, any>, ...infer Tail]
+  : T extends [INodeModelType<infer P, any>, ...infer Tail]
   ? P & PropsFromTypes<Tail>
   : {};
 
-type OthersFromTypes<T> = T extends IModelType<any, infer O>
+type OthersFromTypes<T> = T extends INodeModelType<any, infer O>
   ? O
-  : T extends [IModelType<any, infer O>, ...infer Tail]
+  : T extends [INodeModelType<any, infer O>, ...infer Tail]
   ? O & OthersFromTypes<Tail>
   : {};
 
 type ComposeFactory = {
-  <Types extends [IAnyModelType, ...IAnyModelType[]]>(name: string, ...types: Types): IModelType<
+  <Types extends [IAnyNodeModelType, ...IAnyNodeModelType[]]>(name: string, ...types: Types): INodeModelType<
     PropsFromTypes<Types>,
     OthersFromTypes<Types>
   >;
-  <Types extends [IAnyModelType, ...IAnyModelType[]]>(...types: Types): IModelType<PropsFromTypes<Types>, OthersFromTypes<Types>>;
+  <Types extends [IAnyNodeModelType, ...IAnyNodeModelType[]]>(...types: Types): INodeModelType<
+    PropsFromTypes<Types>,
+    OthersFromTypes<Types>
+  >;
 };
 
-export const compose: ComposeFactory = (nameOrType: IAnyModelType | string, ...types: IAnyModelType[]): IAnyModelType => {
+export const compose: ComposeFactory = (nameOrType: IAnyNodeModelType | string, ...types: IAnyNodeModelType[]): IAnyNodeModelType => {
   let name: string | undefined = undefined;
   if (typeof nameOrType == "string") {
     name = nameOrType;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,1 +1,5 @@
+/** Thrown when an action is invoked on a read-only model instance */
 export class CantRunActionError extends Error {}
+
+/** Thrown when an invalid registration is passed to the class model register function */
+export class RegistrationError extends Error {}

--- a/src/late.ts
+++ b/src/late.ts
@@ -1,8 +1,9 @@
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { IAnyType, InstantiateContext } from "./types";
+import { ensureRegistered } from "./class-model";
+import type { IAnyType, InstanceWithoutSTNTypeForType, InstantiateContext } from "./types";
 
-class LateType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputType"], T["InstanceTypeWithoutSTN"]> {
+class LateType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputType"], InstanceWithoutSTNTypeForType<T>> {
   private cachedType: T | null | undefined;
 
   constructor(private readonly fn: () => T) {
@@ -19,6 +20,7 @@ class LateType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputTyp
 
   private get type() {
     this.cachedType ??= this.fn();
+    ensureRegistered(this.cachedType);
     return this.cachedType;
   }
 }

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,11 +1,12 @@
 import type { IInterceptor, IMapDidChange, IMapWillChange, Lambda } from "mobx";
 import { isStateTreeNode, types } from "mobx-state-tree";
 import { BaseType, setParent, setType } from "./base";
+import { ensureRegistered } from "./class-model";
 import { getSnapshot } from "./snapshot";
-import { $type } from "./symbols";
+import { $readOnly, $type } from "./symbols";
 import type { CreateTypes, IAnyStateTreeNode, IAnyType, IMapType, IMSTMap, Instance, InstantiateContext, SnapshotOut } from "./types";
 
-export class QuickMap<T extends IAnyType> extends Map<string, T["InstanceType"]> implements IMSTMap<T> {
+export class QuickMap<T extends IAnyType> extends Map<string, Instance<T>> implements IMSTMap<T> {
   static get [Symbol.species]() {
     return Map;
   }
@@ -14,6 +15,10 @@ export class QuickMap<T extends IAnyType> extends Map<string, T["InstanceType"]>
 
   get [Symbol.toStringTag]() {
     return "Map" as const;
+  }
+
+  get [$readOnly]() {
+    return true;
   }
 
   forEach(callbackfn: (value: Instance<T>, key: string, map: this) => void, thisArg?: any): void {
@@ -97,5 +102,6 @@ class MapType<T extends IAnyType> extends BaseType<
 }
 
 export const map = <T extends IAnyType>(childrenType: T): IMapType<T> => {
+  ensureRegistered(childrenType);
   return new MapType(childrenType);
 };

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1,11 +1,12 @@
 import { types as mstTypes } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { IAnyStateTreeNode, IAnyType, IMaybeNullType, IMaybeType, InstantiateContext } from "./types";
+import { ensureRegistered } from "./class-model";
+import type { IAnyStateTreeNode, IAnyType, IMaybeNullType, IMaybeType, InstanceWithoutSTNTypeForType, InstantiateContext } from "./types";
 
 class MaybeType<Type extends IAnyType> extends BaseType<
   Type["InputType"] | undefined,
   Type["OutputType"] | undefined,
-  Type["InstanceTypeWithoutSTN"] | undefined
+  InstanceWithoutSTNTypeForType<Type> | undefined
 > {
   constructor(private type: Type) {
     super(mstTypes.maybe(type.mstType));
@@ -29,7 +30,7 @@ class MaybeType<Type extends IAnyType> extends BaseType<
 class MaybeNullType<Type extends IAnyType> extends BaseType<
   Type["InputType"] | null | undefined,
   Type["OutputType"] | null,
-  Type["InstanceTypeWithoutSTN"] | null
+  InstanceWithoutSTNTypeForType<Type> | null
 > {
   constructor(private type: Type) {
     super(mstTypes.maybeNull(type.mstType));
@@ -57,9 +58,11 @@ class MaybeNullType<Type extends IAnyType> extends BaseType<
 }
 
 export const maybe = <T extends IAnyType>(type: T): IMaybeType<T> => {
+  ensureRegistered(type);
   return new MaybeType(type);
 };
 
 export const maybeNull = <T extends IAnyType>(type: T): IMaybeNullType<T> => {
+  ensureRegistered(type);
   return new MaybeNullType(type);
 };

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,13 +1,14 @@
 import type { IAnyModelType as MSTAnyModelType, IAnyType as MSTAnyType } from "mobx-state-tree";
 import { isReferenceType, isStateTreeNode as mstIsStateTreeNode, types as mstTypes } from "mobx-state-tree";
 import { types } from ".";
-import { BaseType, setParent, setType } from "./base";
+import { BaseType, setParent } from "./base";
+import { ensureRegistered } from "./class-model";
 import { CantRunActionError } from "./errors";
-import { $identifier, $type } from "./symbols";
+import { $identifier, $readOnly, $type } from "./symbols";
 import type {
   IAnyStateTreeNode,
   IAnyType,
-  IModelType,
+  INodeModelType,
   InputsForModel,
   InputTypesForModelProps,
   Instance,
@@ -21,7 +22,7 @@ import type {
   TypesForModelPropsDeclaration,
 } from "./types";
 
-const propsFromModelPropsDeclaration = <Props extends ModelPropertiesDeclaration>(
+export const propsFromModelPropsDeclaration = <Props extends ModelPropertiesDeclaration>(
   propsDecl: Props
 ): TypesForModelPropsDeclaration<Props> => {
   const props: Record<string, IAnyType> = {};
@@ -42,6 +43,7 @@ const propsFromModelPropsDeclaration = <Props extends ModelPropertiesDeclaration
           props[name] = types.optional(types.Date, value);
           break;
         }
+        ensureRegistered(value);
         props[name] = value;
         break;
     }
@@ -49,7 +51,7 @@ const propsFromModelPropsDeclaration = <Props extends ModelPropertiesDeclaration
   return props as TypesForModelPropsDeclaration<Props>;
 };
 
-const mstPropsFromQuickProps = <Props extends ModelProperties>(props: Props): Record<string, MSTAnyType> => {
+export const mstPropsFromQuickProps = <Props extends ModelProperties>(props: Props): Record<string, MSTAnyType> => {
   const mstProps: Record<string, MSTAnyType> = {};
   for (const name in props) {
     mstProps[name] = props[name].mstType;
@@ -82,7 +84,36 @@ const assignProps = (target: any, source: any) => {
   }
 };
 
-const defaultThrowAction = (name: string) => {
+export const instantiateInstanceFromProperties = (
+  instance: any,
+  snapshot: Record<string, any> | undefined,
+  properties: ModelProperties,
+  identifierProp: string | undefined,
+  context: InstantiateContext
+) => {
+  for (const propName in properties) {
+    const propType = properties[propName];
+    if (isReferenceType(propType.mstType)) {
+      context.referencesToResolve.push(() => {
+        const propValue = propType.instantiate(snapshot?.[propName], context);
+        instance[propName] = propValue;
+      });
+      continue;
+    }
+
+    const propValue = propType.instantiate(snapshot?.[propName], context);
+    setParent(propValue, instance);
+    instance[propName] = propValue;
+  }
+
+  if (identifierProp) {
+    const id = instance[identifierProp];
+    Object.defineProperty(instance, $identifier, { value: id });
+    context.referenceCache.set(id, instance);
+  }
+};
+
+export const defaultThrowAction = (name: string) => {
   return () => {
     throw new CantRunActionError(`Can't run action "${name}" for a readonly instance`);
   };
@@ -111,7 +142,8 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
     } else {
       this.prototype = {} as this["InstanceType"];
     }
-    setType(this.prototype, this);
+    (this.prototype as any)[$type] = this;
+    (this.prototype as any)[$readOnly] = true;
   }
 
   views<Views extends ModelViews>(fn: (self: Instance<this>) => Views): ModelType<Props, Others & Views> {
@@ -145,7 +177,7 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
     return new ModelType(this.properties, this.initializers, this.mstType.named(newName));
   }
 
-  volatile<VolatileState extends ModelViews>(fn: (self: Instance<this>) => VolatileState): IModelType<Props, Others & VolatileState> {
+  volatile<VolatileState extends ModelViews>(fn: (self: Instance<this>) => VolatileState): INodeModelType<Props, Others & VolatileState> {
     const init = (self: Instance<this>) => assignProps(self, fn(self));
     return new ModelType<Props, Others & VolatileState>(this.properties, [...this.initializers, init], this.mstType.volatile(fn));
   }
@@ -156,7 +188,7 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
       views?: Views;
       state?: VolatileState;
     }
-  ): IModelType<Props, Others & Actions & Views & VolatileState> {
+  ): INodeModelType<Props, Others & Actions & Views & VolatileState> {
     const init = (self: Instance<this>) => {
       const result = fn(self);
       assignProps(self, result.views);
@@ -201,27 +233,7 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
   instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext): this["InstanceType"] {
     const instance: Record<string | symbol, any> = Object.create(this.prototype);
 
-    for (const propName in this.properties) {
-      const propType = this.properties[propName];
-      if (isReferenceType(propType.mstType)) {
-        context.referencesToResolve.push(() => {
-          const propValue = propType.instantiate(snapshot?.[propName], context);
-          instance[propName] = propValue;
-        });
-        continue;
-      }
-
-      const propValue = propType.instantiate(snapshot?.[propName], context);
-      setParent(propValue, instance);
-      instance[propName] = propValue;
-    }
-
-    if (this.identifierProp) {
-      const id = instance[this.identifierProp];
-      Object.defineProperty(instance, $identifier, { value: id });
-      context.referenceCache.set(id, instance);
-    }
-
+    instantiateInstanceFromProperties(instance, snapshot, this.properties, this.identifierProp, context);
     for (const init of this.initializers) {
       init(instance);
     }
@@ -231,16 +243,16 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
 }
 
 export type ModelFactory = {
-  (): IModelType<{}, {}>;
-  (name: string): IModelType<{}, {}>;
-  <Props extends ModelPropertiesDeclaration>(properties: Props): IModelType<TypesForModelPropsDeclaration<Props>, {}>;
-  <Props extends ModelPropertiesDeclaration>(name: string, properties: Props): IModelType<TypesForModelPropsDeclaration<Props>, {}>;
+  (): INodeModelType<{}, {}>;
+  (name: string): INodeModelType<{}, {}>;
+  <Props extends ModelPropertiesDeclaration>(properties: Props): INodeModelType<TypesForModelPropsDeclaration<Props>, {}>;
+  <Props extends ModelPropertiesDeclaration>(name: string, properties: Props): INodeModelType<TypesForModelPropsDeclaration<Props>, {}>;
 };
 
 export const model: ModelFactory = <Props extends ModelPropertiesDeclaration>(
   nameOrProperties?: string | Props,
   properties?: Props
-): IModelType<TypesForModelPropsDeclaration<Props>, {}> => {
+): INodeModelType<TypesForModelPropsDeclaration<Props>, {}> => {
   let propsDecl: Props;
   let name = "model";
   if (typeof nameOrProperties === "string") {

--- a/src/optional.ts
+++ b/src/optional.ts
@@ -1,13 +1,22 @@
 import { types as mstTypes } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { CreateTypes, IAnyStateTreeNode, IAnyType, InstantiateContext, IOptionalType, ValidOptionalValue } from "./types";
+import { ensureRegistered } from "./class-model";
+import type {
+  CreateTypes,
+  IAnyStateTreeNode,
+  IAnyType,
+  InstanceWithoutSTNTypeForType,
+  InstantiateContext,
+  IOptionalType,
+  ValidOptionalValue,
+} from "./types";
 
 export type DefaultFuncOrValue<T extends IAnyType> = T["InputType"] | T["OutputType"] | (() => CreateTypes<T>);
 
 class OptionalType<T extends IAnyType, OptionalValues extends [ValidOptionalValue, ...ValidOptionalValue[]]> extends BaseType<
   T["InputType"] | OptionalValues[number],
   T["OutputType"],
-  T["InstanceTypeWithoutSTN"]
+  InstanceWithoutSTNTypeForType<T>
 > {
   constructor(
     readonly type: T,
@@ -65,5 +74,6 @@ export const optional: OptionalFactory = <T extends IAnyType, OptionalValues ext
   defaultValue: DefaultFuncOrValue<T>,
   undefinedValues?: OptionalValues
 ): IOptionalType<T, OptionalValues> => {
+  ensureRegistered(type);
   return new OptionalType(type, defaultValue, undefinedValues);
 };

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -2,14 +2,15 @@ import type { OnReferenceInvalidated, ReferenceOptions, ReferenceOptionsGetSet }
 import { types } from "mobx-state-tree";
 import type { ReferenceT } from "mobx-state-tree/dist/internal";
 import { BaseType } from "./base";
-import type { IAnyComplexType, IMaybeType, InstantiateContext, IReferenceType } from "./types";
+import { ensureRegistered } from "./class-model";
+import type { IAnyComplexType, IMaybeType, InstanceWithoutSTNTypeForType, InstantiateContext, IReferenceType } from "./types";
 
 export type SafeReferenceOptions<T extends IAnyComplexType> = (ReferenceOptionsGetSet<T["mstType"]> | Record<string, unknown>) & {
   acceptsUndefined?: boolean;
   onInvalidated?: OnReferenceInvalidated<ReferenceT<T["mstType"]>>;
 };
 
-class ReferenceType<TargetType extends IAnyComplexType> extends BaseType<string, string, TargetType["InstanceTypeWithoutSTN"]> {
+class ReferenceType<TargetType extends IAnyComplexType> extends BaseType<string, string, InstanceWithoutSTNTypeForType<TargetType>> {
   constructor(readonly targetType: IAnyComplexType, options?: ReferenceOptions<TargetType["mstType"]>) {
     super(types.reference(targetType.mstType, options));
   }
@@ -30,7 +31,7 @@ class ReferenceType<TargetType extends IAnyComplexType> extends BaseType<string,
 class SafeReferenceType<TargetType extends IAnyComplexType> extends BaseType<
   string | undefined,
   string | undefined,
-  TargetType["InstanceTypeWithoutSTN"] | undefined
+  InstanceWithoutSTNTypeForType<TargetType> | undefined
 > {
   constructor(readonly targetType: IAnyComplexType, options?: SafeReferenceOptions<TargetType>) {
     super(types.safeReference(targetType.mstType, options));
@@ -53,6 +54,7 @@ export const reference = <TargetType extends IAnyComplexType>(
   targetType: TargetType,
   options?: ReferenceOptions<TargetType["mstType"]>
 ): IReferenceType<TargetType> => {
+  ensureRegistered(targetType);
   return new ReferenceType(targetType, options);
 };
 
@@ -60,5 +62,6 @@ export const safeReference = <TargetType extends IAnyComplexType>(
   targetType: TargetType,
   options?: SafeReferenceOptions<TargetType>
 ): IMaybeType<IReferenceType<TargetType>> => {
+  ensureRegistered(targetType);
   return new SafeReferenceType(targetType, options);
 };

--- a/src/refinement.ts
+++ b/src/refinement.ts
@@ -1,10 +1,10 @@
 import type { Instance } from "mobx-state-tree";
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { IAnyType, InstantiateContext, IType } from "./types";
+import type { IAnyType, InstanceWithoutSTNTypeForType, InstantiateContext, IType } from "./types";
 
-class RefinementType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputType"], T["InstanceTypeWithoutSTN"]> {
-  constructor(readonly type: T, readonly predicate: (snapshot: T["InstanceType"] | Instance<T["mstType"]>) => boolean) {
+class RefinementType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputType"], InstanceWithoutSTNTypeForType<T>> {
+  constructor(readonly type: T, readonly predicate: (snapshot: Instance<T> | Instance<T["mstType"]>) => boolean) {
     super(types.refinement(type.mstType, predicate));
   }
 
@@ -24,7 +24,7 @@ class RefinementType<T extends IAnyType> extends BaseType<T["InputType"], T["Out
 
 export const refinement = <T extends IAnyType>(
   type: T,
-  predicate: (snapshot: T["InstanceType"] | Instance<T["mstType"]>) => boolean
-): IType<T["InputType"], T["OutputType"], T["InstanceTypeWithoutSTN"]> => {
+  predicate: (snapshot: Instance<T> | Instance<T["mstType"]>) => boolean
+): IType<T["InputType"], T["OutputType"], InstanceWithoutSTNTypeForType<T>> => {
   return new RefinementType(type, predicate);
 };

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -4,9 +4,9 @@ import { getType, isModelType, isReferenceType, isStateTreeNode } from "./api";
 import { QuickArray } from "./array";
 import { QuickMap } from "./map";
 import { $identifier } from "./symbols";
-import type { IStateTreeNode, IType } from "./types";
+import type { IClassModelType, IStateTreeNode, IType } from "./types";
 
-export function getSnapshot<S>(value: IStateTreeNode<IType<any, S, any>>): S {
+export function getSnapshot<S>(value: IStateTreeNode<IType<any, S, any>> | IStateTreeNode<IClassModelType<any, any, S>>): S {
   if (mstIsStateTreeNode(value)) {
     return mstGetSnapshot<S>(value as MSTStateTreeNode);
   }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -27,3 +27,10 @@ export const $requiresRegistration = Symbol.for("MQT_requiresRegistration");
  * @hidden
  **/
 export const $registered = Symbol.for("MQT_registered");
+
+/**
+ * For tagging functions that define volatiles in the class model API
+ *
+ * @hidden
+ **/
+export const $volatileDefiner = Symbol.for("MQT_volatileDefiner");

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -12,3 +12,18 @@ export const $identifier = Symbol.for("MQT_identifier");
 
 /** @hidden */
 export const $type = Symbol.for("MQT_type");
+
+/** @hidden */
+export const $readOnly = Symbol.for("MQT_readonly");
+
+/**
+ * Set on an type when that type needs to be registered with a decorator before it can be used
+ * @hidden
+ **/
+export const $requiresRegistration = Symbol.for("MQT_requiresRegistration");
+
+/**
+ * Set on a type when it has been properly registered with a decorator
+ * @hidden
+ **/
+export const $registered = Symbol.for("MQT_registered");

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,10 +36,10 @@ export type IDateType = IType<Date | number, number, Date>;
 export type IAnyComplexType = IType<any, any, object> | IClassModelType<any, any>;
 
 /** Given any MQT type, get the type of an instance of the MQT type */
-export type InstanceWithoutSTNTypeForType<T extends IAnyType> = T extends IType<any, any, any>
-  ? T["InstanceTypeWithoutSTN"]
-  : T extends IClassModelType<any, any>
+export type InstanceWithoutSTNTypeForType<T extends IAnyType> = T extends IClassModelType<any, any>
   ? InstanceType<T>
+  : T extends IType<any, any, any>
+  ? T["InstanceTypeWithoutSTN"]
   : T;
 
 export interface INodeModelType<Props extends ModelProperties, Others>
@@ -84,7 +84,7 @@ export interface IAnyNodeModelType extends IType<any, any, any> {
 }
 
 /**
- * IClassModelType represents the type of MQT class models. This is the class-level type, not the instance level type, so it has a typed `new()` and all the static functions/properties of a MQT class model.
+ * `IClassModelType` represents the type of MQT class models. This is the class-level type, not the instance level type, so it has a typed `new()` and all the static functions/properties of a MQT class model.
  *
  * Note: `IClassModelType` is regrettably *not* an `IType`. `IClassModelType` is an interface that all class model classes implement. It's also the concrete type of the base class models returned by the ClassModel class factory. It'd be great if we could make `IClassModelType` extend `IType`, but, we would need to ensure the `Instance` part of `IType` is updated to reference the final version of the declared class. Crucially, there's no TypeScript way to get the resulting type of a class *after* it has been defined to then start referring to it within an interface that the class implements. Decorators don't let us get a reference to the finished type of a class, nor do they let us return a new type that could reference it, so, we can't mutate the type of a defined class model. Hence, we can't make `IClassModelType` extend `IType` without it capturing a reference to an outdated `Instance` type that doesn't have the methods / properties added after class extension. Sad.
  *

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { IInterceptor, IMapDidChange, IMapWillChange, Lambda } from "mobx";
 import type { IAnyType as MSTAnyType } from "mobx-state-tree";
-import type { $quickType, $type } from "./symbols";
+import type { VolatileMetadata } from "./class-model";
+import type { $quickType, $registered, $type } from "./symbols";
 
 export type { IJsonPatch, IMiddlewareEvent, IPatchRecorder, ReferenceOptions, UnionOptions } from "mobx-state-tree";
 
@@ -25,12 +26,23 @@ export interface IType<InputType, OutputType, InstanceType> {
   instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext): this["InstanceType"];
 }
 
-export type IAnyType = IType<any, any, any>;
+/**
+ * Any type object in the system.
+ * Examples: `types.string`, `types.model({})`, `types.array(types.string)`, `class Example extends ClassModel({})`, etc.
+ */
+export type IAnyType = IType<any, any, any> | IClassModelType<any, any, any>;
 export type ISimpleType<T> = IType<T, T, T>;
 export type IDateType = IType<Date | number, number, Date>;
-export type IAnyComplexType = IType<any, any, object>;
+export type IAnyComplexType = IType<any, any, object> | IClassModelType<any, any>;
 
-export interface IModelType<Props extends ModelProperties, Others>
+/** Given any MQT type, get the type of an instance of the MQT type */
+export type InstanceWithoutSTNTypeForType<T extends IAnyType> = T extends IType<any, any, any>
+  ? T["InstanceTypeWithoutSTN"]
+  : T extends IClassModelType<any, any>
+  ? InstanceType<T>
+  : T;
+
+export interface INodeModelType<Props extends ModelProperties, Others>
   extends IType<
     InputsForModel<InputTypesForModelProps<Props>>,
     OutputTypesForModelProps<Props>,
@@ -38,57 +50,123 @@ export interface IModelType<Props extends ModelProperties, Others>
   > {
   readonly properties: Props;
 
-  named(newName: string): IModelType<Props, Others>;
-  props<Props2 extends ModelPropertiesDeclaration>(props: Props2): IModelType<Props & TypesForModelPropsDeclaration<Props2>, Others>;
-  views<V extends ModelViews>(fn: (self: Instance<this>) => V): IModelType<Props, Others & V>;
-  actions<A extends ModelActions>(fn: (self: Instance<this>) => A): IModelType<Props, Others & A>;
-  volatile<TP extends ModelViews>(fn: (self: Instance<this>) => TP): IModelType<Props, Others & TP>;
+  named(newName: string): INodeModelType<Props, Others>;
+  props<Props2 extends ModelPropertiesDeclaration>(props: Props2): INodeModelType<Props & TypesForModelPropsDeclaration<Props2>, Others>;
+  views<V extends ModelViews>(fn: (self: Instance<this>) => V): INodeModelType<Props, Others & V>;
+  actions<A extends ModelActions>(fn: (self: Instance<this>) => A): INodeModelType<Props, Others & A>;
+  volatile<TP extends ModelViews>(fn: (self: Instance<this>) => TP): INodeModelType<Props, Others & TP>;
   extend<A extends ModelActions, V extends ModelViews, VS extends ModelViews>(
     fn: (self: Instance<this>) => {
       actions?: A;
       views?: V;
       state?: VS;
     }
-  ): IModelType<Props, Others & A & V & VS>;
+  ): INodeModelType<Props, Others & A & V & VS>;
 }
 
 // TODO see if we can make this work for `IModelType<any, any>`, or some other way to simplify
 // This isn't quite IModelType<any, any>. In particular, InputType is any, which is key to make a lot of things typecheck
-export interface IAnyModelType extends IType<any, any, any> {
+export interface IAnyNodeModelType extends IType<any, any, any> {
   readonly properties: any;
 
-  named(newName: string): IAnyModelType;
-  props<Props2 extends ModelPropertiesDeclaration>(props: Props2): IAnyModelType;
-  views<V extends ModelViews>(fn: (self: Instance<this>) => V): IAnyModelType;
-  actions<A extends ModelActions>(fn: (self: Instance<this>) => A): IAnyModelType;
-  volatile<TP extends ModelViews>(fn: (self: Instance<this>) => TP): IAnyModelType;
+  named(newName: string): IAnyNodeModelType;
+  props<Props2 extends ModelPropertiesDeclaration>(props: Props2): IAnyNodeModelType;
+  views<V extends ModelViews>(fn: (self: Instance<this>) => V): IAnyNodeModelType;
+  actions<A extends ModelActions>(fn: (self: Instance<this>) => A): IAnyNodeModelType;
+  volatile<TP extends ModelViews>(fn: (self: Instance<this>) => TP): IAnyNodeModelType;
   extend<A extends ModelActions, V extends ModelViews, VS extends ModelViews>(
     fn: (self: Instance<this>) => {
       actions?: A;
       views?: V;
       state?: VS;
     }
-  ): IAnyModelType;
+  ): IAnyNodeModelType;
 }
+
+/**
+ * IClassModelType represents the type of MQT class models. This is the class-level type, not the instance level type, so it has a typed `new()` and all the static functions/properties of a MQT class model.
+ *
+ * Note: `IClassModelType` is regrettably *not* an `IType`. `IClassModelType` is an interface that all class model classes implement. It's also the concrete type of the base class models returned by the ClassModel class factory. It'd be great if we could make `IClassModelType` extend `IType`, but, we would need to ensure the `Instance` part of `IType` is updated to reference the final version of the declared class. Crucially, there's no TypeScript way to get the resulting type of a class *after* it has been defined to then start referring to it within an interface that the class implements. Decorators don't let us get a reference to the finished type of a class, nor do they let us return a new type that could reference it, so, we can't mutate the type of a defined class model. Hence, we can't make `IClassModelType` extend `IType` without it capturing a reference to an outdated `Instance` type that doesn't have the methods / properties added after class extension. Sad.
+ *
+ * Instead, we have this type, and we compute the instance type of a class model in a different way than `IType`. The type of an instance of a class is the class itself. Whereas usually, we need to do:
+ *
+ * type Instance<T extends IAnyType> = T["InstanceType"];
+ *
+ * in the case of class models, we can do:
+ *
+ * type Instance<T extends IClassModelType> = InstanceType<T>;
+ *
+ * using the `InstanceType` built-in helper type from TypeScript.
+ **/
+export interface IClassModelType<
+  Props extends ModelProperties,
+  InputType = InputsForModel<InputTypesForModelProps<Props>>,
+  OutputType = OutputTypesForModelProps<Props>
+> {
+  readonly [$quickType]: undefined;
+  readonly [$registered]: true;
+
+  readonly InputType: InputType;
+  readonly OutputType: OutputType;
+
+  readonly properties: Props;
+  readonly name: string;
+  mstType: MSTAnyType;
+
+  /** @hidden */
+  volatiles: Record<string, VolatileMetadata>;
+
+  /** @hidden */
+  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext): InstanceType<this>;
+
+  is(value: IAnyStateTreeNode): value is InstanceType<this>;
+  is(value: any): value is this["InputType"] | InstanceType<this>;
+
+  /**
+   * Create a new instance of this class model.
+   * Use the `new` operator if possible
+   */
+  create<T extends IAnyType>(this: T, snapshot?: SnapshotIn<T>, env?: any): Instance<T>;
+  /**
+   * Create a new instance of this class model.
+   * Use the `new` operator if possible for performance
+   */
+  createReadOnly<T extends IAnyType>(this: T, snapshot?: SnapshotIn<T>, env?: any): Instance<T>;
+
+  isMQTClassModel: true;
+
+  /**
+   * Construct a new readonly instance of this class model.
+   **/
+  new (attrs?: this["InputType"], env?: any, context?: InstantiateContext): InstanceTypesForModelProps<
+    TypesForModelPropsDeclaration<Props>
+  > & {
+    readonly [$type]?: [IClassModelType<Props, InputType>] | [any];
+  };
+}
+
+export type IAnyClassModelType = IClassModelType<any, any>;
+
+export type IAnyModelType = IAnyNodeModelType | IAnyClassModelType;
 
 export type IMaybeType<T extends IAnyType> = IType<
   T["InputType"] | undefined,
   T["OutputType"] | undefined,
-  T["InstanceTypeWithoutSTN"] | undefined
+  InstanceWithoutSTNTypeForType<T> | undefined
 >;
 
 export type IMaybeNullType<T extends IAnyType> = IType<
   T["InputType"] | null | undefined,
   T["OutputType"] | null,
-  T["InstanceTypeWithoutSTN"] | null
+  InstanceWithoutSTNTypeForType<T> | null
 >;
 
-export type IReferenceType<T extends IAnyComplexType> = IType<string, string, T["InstanceTypeWithoutSTN"]>;
+export type IReferenceType<T extends IAnyComplexType> = IType<string, string, InstanceWithoutSTNTypeForType<T>>;
 
 export type IOptionalType<T extends IAnyType, OptionalValues extends ValidOptionalValue[]> = IType<
   T["InputType"] | OptionalValues[number],
   T["OutputType"],
-  T["InstanceTypeWithoutSTN"]
+  InstanceWithoutSTNTypeForType<T>
 >;
 
 export type IMapType<T extends IAnyType> = IType<Record<string, T["InputType"]> | undefined, Record<string, T["OutputType"]>, IMSTMap<T>>;
@@ -98,7 +176,7 @@ export type IArrayType<T extends IAnyType> = IType<Array<T["InputType"]> | undef
 export type IUnionType<Types extends [IAnyType, ...IAnyType[]]> = IType<
   Types[number]["InputType"],
   Types[number]["OutputType"],
-  Types[number]["InstanceTypeWithoutSTN"]
+  InstanceWithoutSTNTypeForType<Types[number]>
 >;
 
 // Utility types
@@ -142,28 +220,45 @@ export interface IMSTMap<T extends IAnyType> {
 
 /** @hidden */
 export interface InstantiateContext {
-  referenceCache: Map<string, Instance<IAnyModelType>>;
+  referenceCache: Map<string, Instance<IAnyNodeModelType>>;
   referencesToResolve: (() => void)[];
   env?: unknown;
 }
 
+/**
+ * The input type used to create a readonly or observable node from a JSON snapshot.
+ * Reflects which properties are required and optional, and accepts input data in the raw JSON form.
+ */
 export type SnapshotIn<T> = T extends IAnyType ? T["InputType"] : T;
+
+/**
+ * The output type retrieved from a readonly or observable node with all the properties in the JSON.
+ */
 export type SnapshotOut<T> = T extends IAnyType ? T["OutputType"] : T;
-export type Instance<T> = T extends IAnyType ? T["InstanceType"] : T;
+
+/**
+ * A readonly or observable node that has been created and is ready for use.
+ */
+export type Instance<T> = T extends IType<any, any, any> ? T["InstanceType"] : T extends IAnyClassModelType ? InstanceType<T> : T;
+
 export type SnapshotOrInstance<T> = SnapshotIn<T> | Instance<T>;
-export type CreateTypes<T extends IAnyType> = T["InputType"] | T["OutputType"] | T["InstanceType"];
+export type CreateTypes<T extends IAnyType> = T["InputType"] | T["OutputType"] | Instance<T>;
 
 export type ValidOptionalValue = string | boolean | number | null | undefined;
 
-export interface IStateTreeNode<T extends IAnyType = IAnyType> {
+export type IStateTreeNode<T extends IAnyType = IAnyType> = {
   readonly [$type]?: [T] | [any];
-}
+};
 
 export type StateTreeNode<T, IT extends IAnyType> = T extends object ? T & IStateTreeNode<IT> : T;
 export type IAnyStateTreeNode = StateTreeNode<any, IAnyType>;
 
+/** The incoming properties passed to a types.model() or ClassModel() model factory */
 export type ModelPropertiesDeclaration = Record<string, string | number | boolean | Date | IAnyType>;
+
+/** The processed properties describing the shape of a model */
 export type ModelProperties = Record<string, IAnyType>;
+
 export type ModelActions = Record<string, Function>;
 export type ModelViews = Record<string, unknown>;
 
@@ -196,5 +291,5 @@ export type OutputTypesForModelProps<T extends ModelProperties> = {
 };
 
 export type InstanceTypesForModelProps<T extends ModelProperties> = {
-  [K in keyof T]: T[K]["InstanceType"];
+  [K in keyof T]: Instance<T[K]>;
 };

--- a/src/union.ts
+++ b/src/union.ts
@@ -1,12 +1,13 @@
 import type { UnionOptions } from "mobx-state-tree";
 import { types as mstTypes } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { IAnyType, InstantiateContext, IUnionType } from "./types";
+import { ensureRegistered } from "./class-model";
+import type { IAnyType, InstanceWithoutSTNTypeForType, InstantiateContext, IUnionType } from "./types";
 
 class UnionType<Types extends IAnyType[]> extends BaseType<
   Types[number]["InputType"],
   Types[number]["OutputType"],
-  Types[number]["InstanceTypeWithoutSTN"]
+  InstanceWithoutSTNTypeForType<Types[number]>
 > {
   constructor(private types: Types, readonly options?: UnionOptions) {
     super(options ? mstTypes.union(options, ...types.map((x) => x.mstType)) : mstTypes.union(...types.map((x) => x.mstType)));
@@ -27,9 +28,11 @@ class UnionType<Types extends IAnyType[]> extends BaseType<
 }
 
 export const union = <Types extends [IAnyType, ...IAnyType[]]>(...types: Types): IUnionType<Types> => {
+  types.forEach(ensureRegistered);
   return new UnionType(types);
 };
 
 export const lazyUnion = <Types extends [IAnyType, ...IAnyType[]]>(...types: Types): IUnionType<Types> => {
+  types.forEach(ensureRegistered);
   return new UnionType(types, { eager: false });
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "emitDecoratorMetadata": true,
     "esModuleInterop": true
   },
-  "include": ["./src", "./spec"]
+  "include": ["./src", "./spec", "./bench"]
 }


### PR DESCRIPTION
This introduces a new API for defining models that allows us to construct the read only instances much faster. Without any optimization yet, our primitive benchmark shows a 2.5x speedup for this new API over the existing readonly API:

```
claw ~/C/mobx-quick-tree (class-models) ➜  yarn x spec/bench/cross-framework.ts
yarn run v1.22.10
$ ts-node --transpile-only spec/bench/cross-framework.ts
mobx-state-tree x 4,618 ops/sec ±12.62% (80 runs sampled)
mobx-quick-tree types.model x 98,964 ops/sec ±3.50% (91 runs sampled)
mobx-quick-tree ClassModel x 261,246 ops/sec ±0.22% (92 runs sampled)
Fastest is mobx-quick-tree ClassModel
Slowest is mobx-state-tree
```

## Why something different

The central premise is that `mobx-state-tree`'s API for defining models collects functions that add views and actions in such a way that each view-adder function or action-adder function has to be run once *per* instance. If you have a model like:

```typescript
const Todo = types.model("Todo", {
  name: types.string,
  done: types.boolean
}).actions(self => {
  setDone(done: boolean) {
    self.done = done;
  }
});
```

each time you instantiate a `Todo` with `Todo.create` or `Todo.createReadOnly`, that `self => ({ setDone() {} })` block has to run once to create a new set of actions which close over a new value of self. There's no magic behind the scenes that only runs that function once and re-uses the output between instances -- it's instead re-executed on instantiation every time. NIce API, terrible for performance.

## How to get faster

Instead, we should leverage JavaScripts existing mechanisms for defining what is the same about a bunch of objects once instead of over and over: the prototype chain! Classes (which in JS are just sugar over prototypes) allow us to define something like the `setDone` function once on a prototype, and then create an instance which has that as it's prototype, and not need to re-create `setDone` per instance. This whole PR is about defining a class-based API that leverages this built-in performant approach in JS to power read only instances, while still allowing us to generate the observable instances we need sometimes. It's an inversion from the previous approach to MQT: before, we adapted the MST API to give us readonly instances while conforming to the existing API, but now, we define a new API with a higher performance ceiling, and adapt that API to the slower thing under the hood.

## Outcome

This PR implements ... the whole thing. There's a lot, but I found the whole implementation was quite sensitive to each incoming requirement. Here's what I came up with:

 - MQT `types.models` and `ClassModel()`s can interoperate within the same tree at runtime and typetime
 - No more `types.compose`, only subclassing (but subclassing works)
 - Full support for volatiles and `flow(function * (){})` actions, both of which we use in Gadget
 - Support for dynamically defined classes (class factories like `gadgetDomainModelType`)
 - Still built atop MST for observables -- the observables are just fully derived from the class models
 - Green tests in Gadget https://github.com/gadget-inc/gadget/pull/4974

## Key choices I've made so far

- All classes need to be registered (finalized to do all the internal work) with the `@register` decorator
- All action prototype functions need to be decorated with the `@action` decorator, any volatiles with the `@volatile` decorator
- Any undecorated function or getter becomes an automatic view.
- The type of an observable instance of readonly instance is the same (same as MQT v1)

## Implementation

The implementation of this is scary to be honest. `types.model` was clearly modelled after classes, so the grain of class definitions and MST type defintions match, but getting it to work at runtime and typetime requires lots of fancy stuff. The first tricky part is the types. I think it's key that a new, class based API for MQT is incrementally adoptable so that we can roll it out over time and build confidence, and that means that the existing `types.model` types and MQT class based types need to interoperate. After much fiddling, I think I accomplished this, but it was hard to get `IType` and `IClassModelType` working in harmony. See the note in `IClassModelType` for more info.

Also tricky is the runtime derivation of the observable class from the readonly class. The general approach is to use decorators to add metadata properties using the `Reflect` API. The decorators give us enough structure to hang off of, but ES2020/TS decorators have two key limitations: they can't muck with properties until they are defined, and TS decorators can't change the type. This matters most for volatiles and async actions.

Let's review the requirements:

 - Async actions in MST and plain old mobx are really several chunks of sync action chained together, which some kind of hook system to ensure that each sync bit is wrapped in mobx action wrapper goodness, and that inbetween while awaiting something, the wrapper isn't active. mobx/MST need this hook point to enforce actions are actually the only ones changing data.
 - We want to define async actions on classes

And then the limitations:

 - The only hook system that the mobx or MST folks have come up with that is ergonomic is having userland code build async actions using generators instead of the normal async/await. This is so they have their hook point for every `yield`, where they can be like "oh, a promise!" and disable the action bits for the duration of the promise, and re-active them when it resolves and they pass the value back in to the caller. Generators allow userland to intercept each call to what would be `await` in both node and the browser.
 - *Inside* the async action you use `yield somePromise`, but calling the action still returns a promise, so you still do `await someNode.someAsyncAction()`. This is to stay as normal as possible outside of MST action bodies and not make the whole system use generators. So, to adapt the generator into a normally typed async function, users need to wrap their generator functions in `flow()`.
 - There's no way to automatically adapt an async function into a generator function for MST. If there was, MST would use it already and not require folks to write generators. This means the code on the MQT class model *has* to be in generator form.
 - TypeScript decorators can't change the type of the property they are decorating, so they can't automatically apply the `flow` expression to a prototype level generator function and get the type turned into a nice promise returning type. If you have a class body like this:

```typescript

class Foo {

  https://github.com/flow
  *someAsyncAction() {
  }
```

the return type of that function is locked in as a generator, and `@flow` can't change it. It can do stuff to it at *runtime*, but it can't mutate the type time type. That means that `await someFoo.someAsyncAction()` won't typecheck, as TypeScript will be expecting it to return a generator regardless of what runtime trickery the decorator gets up to. Sad.

So, we need to do the adaptation of the generator function into a promise-returning function for nice caller types with some sort of expression. That's what the `flow()` helper from MST does.

 - To assign a `flow(function * () {})` expression to a property on a class, it becomes an "instance property" instead of a prototype property. That is:

```typescript
class Foo {

  someAsyncAction = flow(function * () {
    yield sleep(100)
  });

}
```

desugars into:

```javascript
class Foo {

  constructor() {
    this.someAsyncAction = flow(function * () {
      yield sleep(100)
    });
  }

}
```

It'd be far more performant in general to have this somehow do a `Foo.prototype.whatever = flow(...)`, but alas, thats not how ES6 expression assignments work. This is a major issue for us though, because this desugaring means that there is nothing to look at to get the flow definition at class definition time. For things defined on the prototype, we can get a handle on them easily at class definition time to send them into mobx land for making the observable instance, but, for these things which aren't set until the constructor, we can't see their value until the constructor runs! After much brain wracking I couldn't find a away around this -- I had to go with a major hack which is to actually construct an instance, let the constructor run, and then pull the resulting expression off of the constructed instance to get a handle on the flow implementation to pass into MST. Yikes.