### PR TITLE
Top level create function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 dist
 node_modules
 yarn.lock
+*.0x
+*-v8.log
+v8-deopt-viewer
+*.cpuprofile

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
     "lint": "yarn run lint:prettier && yarn run lint:eslint",
     "lint:prettier": "prettier --check \"{spec,src}/**/*.{js,ts}\"",
     "lint:eslint": "eslint --quiet --ext ts,tsx spec src",
-    "lint:fix": "eslint --ext ts --fix spec src; prettier --write --check \"{spec,src}/**/*.{js,ts}\"",
+    "lint:fix": "prettier --write --check \"{spec,src}/**/*.{js,ts}\"; eslint --ext ts --fix spec src",
     "build": "rm -rf dist && tsc",
     "watch": "rm -rf dist && tsc --watch --preserveWatchOutput",
     "prepublishOnly": "yarn run build",
     "prerelease": "gitpkg publish",
+    "clean": "rm -rf *.0x *-v8.log",
     "x": "ts-node --transpile-only"
   },
   "dependencies": {
@@ -39,6 +40,8 @@
     "@types/jest": "^29.2.3",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "benchmark": "^2.1.4",
+    "conditional-type-checks": "^1.0.6",
+    "deep-freeze-es6": "^1.4.1",
     "eslint": "^8.28.0",
     "eslint-plugin-jest": "^27.1.6",
     "jest": "^29.3.1",

--- a/spec/array.spec.ts
+++ b/spec/array.spec.ts
@@ -1,9 +1,9 @@
-import { types } from "../src";
+import { create, types } from "../src";
 
 test("can create an array of simple types", () => {
   const arrayType = types.array(types.string);
-  expect(arrayType.createReadOnly()).toEqual([]);
-  expect(arrayType.createReadOnly(["a", "b"])).toEqual(["a", "b"]);
+  expect(create(arrayType, undefined, true)).toEqual([]);
+  expect(create(arrayType, ["a", "b"], true)).toEqual(["a", "b"]);
 });
 
 test("can create an array of complex types", () => {
@@ -14,8 +14,8 @@ test("can create an array of complex types", () => {
 
   const arrayType = types.array(inventoryType);
 
-  expect(arrayType.createReadOnly()).toEqual([]);
-  expect(arrayType.createReadOnly([{ itemName: "A", amount: 10 }, { itemName: "B" }])).toEqual([
+  expect(create(arrayType, undefined, true)).toEqual([]);
+  expect(create(arrayType, [{ itemName: "A", amount: 10 }, { itemName: "B" }], true)).toEqual([
     expect.objectContaining({ itemName: "A", amount: 10 }),
     expect.objectContaining({ itemName: "B", amount: 0 }),
   ]);

--- a/spec/bench/create-many-mqt.ts
+++ b/spec/bench/create-many-mqt.ts
@@ -1,0 +1,6 @@
+import { create } from "../../src";
+import { BigTestModelSnapshot, TestModel } from "../fixtures/TestModel";
+
+for (let x = 0; x < 50_000; ++x) {
+  create(TestModel, BigTestModelSnapshot, true);
+}

--- a/spec/bench/cross-framework.ts
+++ b/spec/bench/cross-framework.ts
@@ -1,4 +1,5 @@
 import { Suite } from "benchmark";
+import { create } from "../../src";
 import { TestModel } from "../fixtures/TestModel";
 
 const suite = new Suite("instantiating same object with different paradigms");
@@ -22,10 +23,10 @@ const TestModelSnapshot: (typeof TestModel)["InputType"] = {
 
 suite
   .add("mobx-state-tree", function () {
-    TestModel.create(TestModelSnapshot);
+    create(TestModel, TestModelSnapshot, false);
   })
   .add("mobx-quick-tree types.model", function () {
-    TestModel.createReadOnly(TestModelSnapshot);
+    create(TestModel, TestModelSnapshot, true);
   })
   .on("cycle", function (event: any) {
     console.log(String(event.target));

--- a/spec/fixtures/TestModel.ts
+++ b/spec/fixtures/TestModel.ts
@@ -1,8 +1,10 @@
+import deepFreeze from "deep-freeze-es6";
 import type { SnapshotIn } from "../../src";
+
 import { types } from "../../src";
 
 export const NamedThing = types
-  .model("BooleanWrapper", {
+  .model("NamedThing", {
     key: types.identifier,
     name: types.string,
   })
@@ -40,7 +42,7 @@ export const TestModel = types
     },
   }));
 
-export const TestModelSnapshot: SnapshotIn<typeof TestModel> = {
+export const TestModelSnapshot: SnapshotIn<typeof TestModel> = deepFreeze({
   bool: true,
   frozen: { test: "string" },
   nested: {
@@ -53,4 +55,33 @@ export const TestModelSnapshot: SnapshotIn<typeof TestModel> = {
       name: "Testy McTest",
     },
   },
-};
+  array: [
+    {
+      key: "other_key",
+      name: "A test array element",
+    },
+  ],
+});
+
+export const BigTestModelSnapshot: SnapshotIn<typeof TestModel> = deepFreeze({
+  bool: true,
+  frozen: { test: "string" },
+  nested: {
+    key: "mixed_up",
+    name: "MiXeD CaSe",
+  },
+  array: [
+    { key: "1", name: "Array Item 1" },
+    { key: "2", name: "Array Item 2" },
+    { key: "3", name: "Array Item 3" },
+    { key: "4", name: "Array Item 4" },
+    { key: "5", name: "Array Item 4" },
+  ],
+  map: {
+    a: { key: "a", name: "Map Item A" },
+    b: { key: "b", name: "Map Item B" },
+    c: { key: "c", name: "Map Item C" },
+    d: { key: "e", name: "Map Item E" },
+    f: { key: "f", name: "Map Item F" },
+  },
+});

--- a/spec/map.spec.ts
+++ b/spec/map.spec.ts
@@ -1,4 +1,4 @@
-import { types } from "../src";
+import { create, types } from "../src";
 
 const InventoryItem = types.model("Inventory Item", {
   name: types.identifier,
@@ -7,14 +7,14 @@ const InventoryItem = types.model("Inventory Item", {
 
 test("can create a map of simple types", () => {
   const mapType = types.map(types.string);
-  expect(mapType.createReadOnly().toJSON()).toEqual({});
-  expect(mapType.createReadOnly({ a: "A", b: "B" }).toJSON()).toEqual(expect.objectContaining({ a: "A", b: "B" }));
+  expect(create(mapType, undefined, true).toJSON()).toEqual({});
+  expect(create(mapType, { a: "A", b: "B" }, true).toJSON()).toEqual(expect.objectContaining({ a: "A", b: "B" }));
 });
 
 test("is can create a map of frozen types from a snapshot", () => {
   const mapType = types.map(types.frozen<string | null>());
   const snapshot = { A: "one", B: null };
-  expect(mapType.createReadOnly(snapshot).toJSON()).toEqual(
+  expect(create(mapType, snapshot, true).toJSON()).toEqual(
     expect.objectContaining({
       A: "one",
       B: null,
@@ -25,8 +25,8 @@ test("is can create a map of frozen types from a snapshot", () => {
 test("can create a map of complex types", () => {
   const mapType = types.map(InventoryItem);
 
-  expect(mapType.createReadOnly().toJSON()).toEqual({});
-  expect(mapType.createReadOnly({ A: { name: "A", amount: 10 }, B: { name: "B" } }).toJSON()).toEqual(
+  expect(create(mapType, undefined, true).toJSON()).toEqual({});
+  expect(create(mapType, { A: { name: "A", amount: 10 }, B: { name: "B" } }, true).toJSON()).toEqual(
     expect.objectContaining({
       A: expect.objectContaining({ name: "A", amount: 10 }),
       B: expect.objectContaining({ name: "B", amount: 0 }),

--- a/spec/optional.spec.ts
+++ b/spec/optional.spec.ts
@@ -1,21 +1,21 @@
-import { types } from "../src";
+import { create, types } from "../src";
 import { TestModel, TestModelSnapshot } from "./fixtures/TestModel";
 
 describe("with no undefined values", () => {
   test("can create simple values", () => {
     const booleanType = types.optional(types.boolean, true);
-    expect(booleanType.createReadOnly(true)).toEqual(true);
-    expect(booleanType.createReadOnly(false)).toEqual(false);
-    expect(booleanType.createReadOnly()).toEqual(true);
+    expect(create(booleanType, true, true)).toEqual(true);
+    expect(create(booleanType, false, true)).toEqual(false);
+    expect(create(booleanType, undefined, true)).toEqual(true);
 
     const stringType = types.optional(types.string, "default");
-    expect(stringType.createReadOnly("test")).toEqual("test");
-    expect(stringType.createReadOnly()).toEqual("default");
+    expect(create(stringType, "test", true)).toEqual("test");
+    expect(create(stringType, undefined, true)).toEqual("default");
   });
 
   test("can create complex values", () => {
     const modelType = types.optional(TestModel, TestModelSnapshot);
-    const modelInstance = modelType.createReadOnly();
+    const modelInstance = create(modelType, undefined, true);
     expect(modelInstance.bool).toEqual(TestModelSnapshot.bool);
     expect(modelInstance.frozen.test).toEqual(TestModelSnapshot.frozen.test);
     expect(modelInstance.nested.name).toEqual(TestModelSnapshot.nested.name);
@@ -25,37 +25,37 @@ describe("with no undefined values", () => {
   test("can create defaults with a function", () => {
     let x = 0;
     const optionalType = types.optional(types.string, () => `Item ${++x}`);
-    expect(optionalType.createReadOnly()).toEqual("Item 1");
-    expect(optionalType.createReadOnly("my value")).toEqual("my value");
-    expect(optionalType.createReadOnly()).toEqual("Item 2");
+    expect(create(optionalType, undefined, true)).toEqual("Item 1");
+    expect(create(optionalType, "my value", true)).toEqual("my value");
+    expect(create(optionalType, undefined, true)).toEqual("Item 2");
   });
 });
 
 describe("with undefined values", () => {
   test("can create simple values", () => {
     const booleanType = types.optional(types.boolean, true, [undefined, null]);
-    expect(booleanType.createReadOnly(true)).toEqual(true);
-    expect(booleanType.createReadOnly(false)).toEqual(false);
-    expect(booleanType.createReadOnly()).toEqual(true);
-    expect(booleanType.createReadOnly(null)).toEqual(true);
+    expect(create(booleanType, true, true)).toEqual(true);
+    expect(create(booleanType, false, true)).toEqual(false);
+    expect(create(booleanType, undefined, true)).toEqual(true);
+    expect(create(booleanType, null, true)).toEqual(true);
 
     const stringType = types.optional(types.string, "default", [undefined, null, ""]);
-    expect(stringType.createReadOnly("test")).toEqual("test");
-    expect(stringType.createReadOnly()).toEqual("default");
-    expect(stringType.createReadOnly(null)).toEqual("default");
-    expect(stringType.createReadOnly("")).toEqual("default");
+    expect(create(stringType, "test", true)).toEqual("test");
+    expect(create(stringType, undefined, true)).toEqual("default");
+    expect(create(stringType, null, true)).toEqual("default");
+    expect(create(stringType, "", true)).toEqual("default");
   });
 
   test("can create complex values", () => {
     const modelType = types.optional(TestModel, TestModelSnapshot, [undefined, null]);
 
-    let modelInstance = modelType.createReadOnly();
+    let modelInstance = create(modelType, undefined, true);
     expect(modelInstance.bool).toEqual(TestModelSnapshot.bool);
     expect(modelInstance.frozen.test).toEqual(TestModelSnapshot.frozen.test);
     expect(modelInstance.nested.name).toEqual(TestModelSnapshot.nested.name);
     expect(modelInstance.nested.lowerCasedName()).toEqual(TestModelSnapshot.nested.name.toLowerCase());
 
-    modelInstance = modelType.createReadOnly(null);
+    modelInstance = create(modelType, null, true);
     expect(modelInstance.bool).toEqual(TestModelSnapshot.bool);
     expect(modelInstance.frozen.test).toEqual(TestModelSnapshot.frozen.test);
     expect(modelInstance.nested.name).toEqual(TestModelSnapshot.nested.name);
@@ -65,8 +65,8 @@ describe("with undefined values", () => {
   test("can create defaults with a function", () => {
     let x = 0;
     const optionalType = types.optional(types.string, () => `Item ${++x}`, [null, undefined]);
-    expect(optionalType.createReadOnly()).toEqual("Item 1");
-    expect(optionalType.createReadOnly("my value")).toEqual("my value");
-    expect(optionalType.createReadOnly(null)).toEqual("Item 2");
+    expect(create(optionalType, undefined, true)).toEqual("Item 1");
+    expect(create(optionalType, "my value", true)).toEqual("my value");
+    expect(create(optionalType, null, true)).toEqual("Item 2");
   });
 });

--- a/spec/reference.spec.ts
+++ b/spec/reference.spec.ts
@@ -1,5 +1,5 @@
 import type { Instance } from "../src";
-import { types } from "../src";
+import { create, types } from "../src";
 
 const Referrable = types.model("Referenced", {
   key: types.identifier,
@@ -23,105 +23,131 @@ const Root = types.model("Reference Model", {
   refs: types.array(Referrable),
 });
 
-test("can resolve valid references", () => {
-  const root = Root.createReadOnly({
-    model: {
-      ref: "item-a",
-    },
-    refs: [
-      { key: "item-a", count: 12 },
-      { key: "item-b", count: 523 },
-    ],
-  });
-
-  expect(root.model.ref).toEqual(
-    expect.objectContaining({
-      key: "item-a",
-      count: 12,
-    })
-  );
-});
-
-test("throws for invalid refs", () => {
-  const createRoot = () =>
-    Root.createReadOnly({
-      model: {
-        ref: "item-c",
+describe("read only node references", () => {
+  test("can resolve valid references", () => {
+    const root = create(
+      Root,
+      {
+        model: {
+          ref: "item-a",
+        },
+        refs: [
+          { key: "item-a", count: 12 },
+          { key: "item-b", count: 523 },
+        ],
       },
-      refs: [
-        { key: "item-a", count: 12 },
-        { key: "item-b", count: 523 },
-      ],
-    });
+      true
+    );
 
-  expect(createRoot).toThrow();
-});
-
-test("can resolve valid safe references", () => {
-  const root = Root.createReadOnly({
-    model: {
-      ref: "item-a",
-      safeRef: "item-b",
-    },
-    refs: [
-      { key: "item-a", count: 12 },
-      { key: "item-b", count: 523 },
-    ],
+    expect(root.model.ref).toEqual(
+      expect.objectContaining({
+        key: "item-a",
+        count: 12,
+      })
+    );
   });
 
-  expect(root.model.safeRef).toEqual(
-    expect.objectContaining({
-      key: "item-b",
-      count: 523,
-    })
-  );
-});
+  test("throws for invalid refs", () => {
+    const createRoot = () =>
+      create(
+        Root,
+        {
+          model: {
+            ref: "item-c",
+          },
+          refs: [
+            { key: "item-a", count: 12 },
+            { key: "item-b", count: 523 },
+          ],
+        },
+        true
+      );
 
-test("does not throw for invalid safe references", () => {
-  const root = Root.createReadOnly({
-    model: {
-      ref: "item-a",
-      safeRef: "item-c",
-    },
-    refs: [
-      { key: "item-a", count: 12 },
-      { key: "item-b", count: 523 },
-    ],
+    expect(createRoot).toThrow();
   });
 
-  expect(root.model.safeRef).toBeUndefined();
-});
+  test("can resolve valid safe references", () => {
+    const root = create(
+      Root,
+      {
+        model: {
+          ref: "item-a",
+          safeRef: "item-b",
+        },
+        refs: [
+          { key: "item-a", count: 12 },
+          { key: "item-b", count: 523 },
+        ],
+      },
+      true
+    );
 
-test("references are equal to the instances they refer to", () => {
-  const root = Root.createReadOnly({
-    model: {
-      ref: "item-a",
-      safeRef: "item-b",
-    },
-    refs: [
-      { key: "item-a", count: 12 },
-      { key: "item-b", count: 523 },
-    ],
+    expect(root.model.safeRef).toEqual(
+      expect.objectContaining({
+        key: "item-b",
+        count: 523,
+      })
+    );
   });
 
-  expect(root.model.ref).toBe(root.refs[0]);
-  expect(root.model.ref).toEqual(root.refs[0]);
-  expect(root.model.ref).toStrictEqual(root.refs[0]);
-});
+  test("does not throw for invalid safe references", () => {
+    const root = create(
+      Root,
+      {
+        model: {
+          ref: "item-a",
+          safeRef: "item-c",
+        },
+        refs: [
+          { key: "item-a", count: 12 },
+          { key: "item-b", count: 523 },
+        ],
+      },
+      true
+    );
 
-test("safe references are equal to the instances they refer to", () => {
-  const root = Root.createReadOnly({
-    model: {
-      ref: "item-a",
-      safeRef: "item-b",
-    },
-    refs: [
-      { key: "item-a", count: 12 },
-      { key: "item-b", count: 523 },
-    ],
+    expect(root.model.safeRef).toBeUndefined();
   });
 
-  expect(root.model.safeRef).toBe(root.refs[1]);
-  expect(root.model.safeRef).toEqual(root.refs[1]);
-  expect(root.model.safeRef).toStrictEqual(root.refs[1]);
+  test("references are equal to the instances they refer to", () => {
+    const root = create(
+      Root,
+      {
+        model: {
+          ref: "item-a",
+          safeRef: "item-b",
+        },
+        refs: [
+          { key: "item-a", count: 12 },
+          { key: "item-b", count: 523 },
+        ],
+      },
+      true
+    );
+
+    expect(root.model.ref).toBe(root.refs[0]);
+    expect(root.model.ref).toEqual(root.refs[0]);
+    expect(root.model.ref).toStrictEqual(root.refs[0]);
+  });
+
+  test("safe references are equal to the instances they refer to", () => {
+    const root = create(
+      Root,
+      {
+        model: {
+          ref: "item-a",
+          safeRef: "item-b",
+        },
+        refs: [
+          { key: "item-a", count: 12 },
+          { key: "item-b", count: 523 },
+        ],
+      },
+      true
+    );
+
+    expect(root.model.safeRef).toBe(root.refs[1]);
+    expect(root.model.safeRef).toEqual(root.refs[1]);
+    expect(root.model.safeRef).toStrictEqual(root.refs[1]);
+  });
 });

--- a/spec/simple.spec.ts
+++ b/spec/simple.spec.ts
@@ -1,9 +1,9 @@
-import { getSnapshot, types } from "../src";
+import { create, getSnapshot, types } from "../src";
 
 describe("boolean", () => {
   test("can create a read-only instance", () => {
-    expect(types.boolean.createReadOnly(true)).toEqual(true);
-    expect(types.boolean.createReadOnly(false)).toEqual(false);
+    expect(create(types.boolean, true, true)).toEqual(true);
+    expect(create(types.boolean, false, true)).toEqual(false);
   });
 
   test("can be verified with is", () => {
@@ -16,8 +16,8 @@ describe("boolean", () => {
 
 describe("string", () => {
   test("can create a read-only instance", () => {
-    expect(types.string.createReadOnly("")).toEqual("");
-    expect(types.string.createReadOnly("words")).toEqual("words");
+    expect(create(types.string, "", true)).toEqual("");
+    expect(create(types.string, "words", true)).toEqual("words");
   });
 
   test("can be verified with is", () => {
@@ -32,8 +32,8 @@ describe("string", () => {
 describe("Date", () => {
   test("can create a read-only instance", () => {
     const date = new Date();
-    expect(types.Date.createReadOnly(date.getTime())).toEqual(date);
-    expect(types.Date.createReadOnly(date)).toEqual(date);
+    expect(create(types.Date, date.getTime(), true)).toEqual(date);
+    expect(create(types.Date, date, true)).toEqual(date);
   });
 
   test("can be verified with is", () => {
@@ -51,7 +51,7 @@ describe("late", () => {
   const lateType = types.late(() => modelType);
 
   test("can create a read-only instance", () => {
-    expect(lateType.createReadOnly({ a: "my value", b: 2 })).toEqual({ a: "my value", b: 2 });
+    expect(create(lateType, { a: "my value", b: 2 }, true)).toEqual({ a: "my value", b: 2 });
   });
 
   test("can be verified with is", () => {
@@ -68,9 +68,9 @@ describe("maybe", () => {
   const maybeType = types.maybe(types.string);
 
   test("can create a read-only instance", () => {
-    expect(maybeType.createReadOnly()).toEqual(undefined);
-    expect(maybeType.createReadOnly(undefined)).toEqual(undefined);
-    expect(maybeType.createReadOnly("value 2")).toEqual("value 2");
+    expect(create(maybeType, undefined, true)).toEqual(undefined);
+    expect(create(maybeType, undefined, true)).toEqual(undefined);
+    expect(create(maybeType, "value 2", true)).toEqual("value 2");
   });
 
   test("can be verified with is", () => {
@@ -86,9 +86,9 @@ describe("maybeNull", () => {
   const maybeNullType = types.maybeNull(types.string);
 
   test("can create a read-only instance", () => {
-    expect(maybeNullType.createReadOnly(null)).toEqual(null);
-    expect(maybeNullType.createReadOnly(undefined)).toEqual(null);
-    expect(maybeNullType.createReadOnly("value 2")).toEqual("value 2");
+    expect(create(maybeNullType, null, true)).toEqual(null);
+    expect(create(maybeNullType, undefined, true)).toEqual(null);
+    expect(create(maybeNullType, "value 2", true)).toEqual("value 2");
   });
 
   test("can be verified with is", () => {
@@ -104,9 +104,9 @@ describe("literal", () => {
   const literal = types.literal("testing");
 
   test("can create a read-only instance", () => {
-    expect(literal.createReadOnly("testing")).toEqual("testing");
-    expect(() => literal.createReadOnly()).toThrow();
-    expect(() => literal.createReadOnly(true as any)).toThrow();
+    expect(create(literal, "testing", true)).toEqual("testing");
+    expect(() => create(literal, undefined, true)).toThrow();
+    expect(() => create(literal, true as any, true)).toThrow();
   });
 
   test("can be verified with is", () => {
@@ -122,16 +122,16 @@ describe("union", () => {
   const unionType = types.union(types.literal("value 1"), types.literal("value 2"));
 
   test("can create a read-only instance", () => {
-    expect(unionType.createReadOnly("value 1")).toEqual("value 1");
-    expect(unionType.createReadOnly("value 2")).toEqual("value 2");
-    expect(() => unionType.createReadOnly("value 3" as any)).toThrow();
+    expect(create(unionType, "value 1", true)).toEqual("value 1");
+    expect(create(unionType, "value 2", true)).toEqual("value 2");
+    expect(() => create(unionType, "value 3" as any, true)).toThrow();
   });
 
   test("can create an eager, read-only instance", () => {
     const unionType = types.lazyUnion(types.literal("value 1"), types.literal("value 2"));
-    expect(unionType.createReadOnly("value 1")).toEqual("value 1");
-    expect(unionType.createReadOnly("value 2")).toEqual("value 2");
-    expect(() => unionType.createReadOnly("value 3" as any)).toThrow();
+    expect(create(unionType, "value 1", true)).toEqual("value 1");
+    expect(create(unionType, "value 2", true)).toEqual("value 2");
+    expect(() => create(unionType, "value 3" as any, true)).toThrow();
   });
 
   test("can be verified with is", () => {
@@ -147,7 +147,7 @@ describe("union", () => {
     const modelTypeA = types.model({ x: types.string });
     const modelTypeB = types.model({ y: types.number });
     const unionType = types.union(modelTypeA, modelTypeB);
-    const unionInstance = unionType.createReadOnly({ x: "test" });
+    const unionInstance = create(unionType, { x: "test" }, true);
 
     expect(getSnapshot(unionInstance)).toEqual(
       expect.objectContaining({
@@ -161,8 +161,8 @@ describe("refinement", () => {
   const smallStringsType = types.refinement(types.string, (v: string) => v.length <= 5);
 
   test("can create a read-only instance", () => {
-    expect(smallStringsType.createReadOnly("small")).toEqual("small");
-    expect(() => smallStringsType.createReadOnly("too big")).toThrow();
+    expect(create(smallStringsType, "small", true)).toEqual("small");
+    expect(() => create(smallStringsType, "too big", true)).toThrow();
   });
 
   test("can be verified with is", () => {
@@ -195,9 +195,9 @@ describe("custom", () => {
   });
 
   test("can create a read-only instance", () => {
-    expect(csvType.createReadOnly("a")).toEqual(["a"]);
-    expect(csvType.createReadOnly("a,b,c")).toEqual(["a", "b", "c"]);
-    expect(() => csvType.createReadOnly()).toThrow();
+    expect(create(csvType, "a", true)).toEqual(["a"]);
+    expect(create(csvType, "a,b,c", true)).toEqual(["a", "b", "c"]);
+    expect(() => create(csvType, undefined, true)).toThrow();
   });
 
   test("can be verified with is", () => {
@@ -214,17 +214,17 @@ describe("enumeration", () => {
   const _enumTypeWithConst = types.enumeration<"a" | "b">(["a", "b"] as const);
 
   test("can create a read-only instance", () => {
-    expect(enumType.createReadOnly("a")).toEqual("a");
-    expect(enumType.createReadOnly("b")).toEqual("b");
-    expect(() => enumType.createReadOnly("c" as any)).toThrow();
+    expect(create(enumType, "a", true)).toEqual("a");
+    expect(create(enumType, "b", true)).toEqual("b");
+    expect(() => create(enumType, "c" as any, true)).toThrow();
   });
 
   test("can create a read-only instance with a name", () => {
     const enumType = types.enumeration<"a" | "b">("AB", ["a", "b"]);
     expect(enumType.name).toEqual("AB");
-    expect(enumType.createReadOnly("a")).toEqual("a");
-    expect(enumType.createReadOnly("b")).toEqual("b");
-    expect(() => enumType.createReadOnly("c" as any)).toThrow();
+    expect(create(enumType, "a", true)).toEqual("a");
+    expect(create(enumType, "b", true)).toEqual("b");
+    expect(() => create(enumType, "c" as any, true)).toThrow();
   });
 
   test("can create a read-only instance with a TypeScript enum", () => {
@@ -235,9 +235,9 @@ describe("enumeration", () => {
 
     const enumType = types.enumeration<Colors>("Color", Object.values(Colors));
     expect(enumType.name).toEqual("Color");
-    expect(enumType.createReadOnly(Colors.Red)).toEqual("Red");
-    expect(enumType.createReadOnly(Colors.Green)).toEqual("Green");
-    expect(() => enumType.createReadOnly("c" as any)).toThrow();
+    expect(create(enumType, Colors.Red, true)).toEqual("Red");
+    expect(create(enumType, Colors.Green, true)).toEqual("Green");
+    expect(() => create(enumType, "c" as any, true)).toThrow();
   });
 
   test("can be verified with is", () => {

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,6 +1,6 @@
 import { isStateTreeNode, types } from "mobx-state-tree";
 import { BaseType, setParent, setType } from "./base";
-import { $type } from "./symbols";
+import { $readOnly, $type } from "./symbols";
 import type { IAnyStateTreeNode, IAnyType, IArrayType, IMSTArray, Instance, InstantiateContext } from "./types";
 
 export class QuickArray<T extends IAnyType> extends Array<T["InstanceType"]> implements IMSTArray<T> {
@@ -12,6 +12,10 @@ export class QuickArray<T extends IAnyType> extends Array<T["InstanceType"]> imp
 
   get [Symbol.toStringTag]() {
     return "Array" as const;
+  }
+
+  get [$readOnly]() {
+    return true;
   }
 
   spliceWithArray(_index: number, _deleteCount?: number, _newItems?: Instance<T>[]): Instance<T>[] {

--- a/src/map.ts
+++ b/src/map.ts
@@ -2,7 +2,7 @@ import type { IInterceptor, IMapDidChange, IMapWillChange, Lambda } from "mobx";
 import { isStateTreeNode, types } from "mobx-state-tree";
 import { BaseType, setParent, setType } from "./base";
 import { getSnapshot } from "./snapshot";
-import { $type } from "./symbols";
+import { $readOnly, $type } from "./symbols";
 import type { CreateTypes, IAnyStateTreeNode, IAnyType, IMapType, IMSTMap, Instance, InstantiateContext, SnapshotOut } from "./types";
 
 export class QuickMap<T extends IAnyType> extends Map<string, T["InstanceType"]> implements IMSTMap<T> {
@@ -14,6 +14,10 @@ export class QuickMap<T extends IAnyType> extends Map<string, T["InstanceType"]>
 
   get [Symbol.toStringTag]() {
     return "Map" as const;
+  }
+
+  get [$readOnly]() {
+    return true;
   }
 
   forEach(callbackfn: (value: Instance<T>, key: string, map: this) => void, thisArg?: any): void {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,9 +1,9 @@
 import type { IAnyModelType as MSTAnyModelType, IAnyType as MSTAnyType } from "mobx-state-tree";
 import { isReferenceType, isStateTreeNode as mstIsStateTreeNode, types as mstTypes } from "mobx-state-tree";
 import { types } from ".";
-import { BaseType, setParent, setType } from "./base";
+import { BaseType, setParent } from "./base";
 import { CantRunActionError } from "./errors";
-import { $identifier, $type } from "./symbols";
+import { $identifier, $readOnly, $type } from "./symbols";
 import type {
   IAnyStateTreeNode,
   IAnyType,
@@ -111,7 +111,8 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
     } else {
       this.prototype = {} as this["InstanceType"];
     }
-    setType(this.prototype, this);
+    (this.prototype as any)[$type] = this;
+    (this.prototype as any)[$readOnly] = true;
   }
 
   views<Views extends ModelViews>(fn: (self: Instance<this>) => Views): ModelType<Props, Others & Views> {

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -12,3 +12,6 @@ export const $identifier = Symbol.for("MQT_identifier");
 
 /** @hidden */
 export const $type = Symbol.for("MQT_type");
+
+/** @hidden */
+export const $readOnly = Symbol.for("MQT_readonly");


### PR DESCRIPTION
This switches the main way that instances are created to `create(Foo)` from `Foo.create()`.