### PR TITLE
Fix typescript types for snapshotting optional types

### DIFF
--- a/spec/class-model.spec.ts
+++ b/spec/class-model.spec.ts
@@ -1,7 +1,7 @@
 import type { Has, IsExact } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
 import type { IAnyType, IClassModelType, ISimpleType, IStateTreeNode, Instance, ModelPropertiesDeclaration, SnapshotIn } from "../src";
-import { flow, getType, isReadOnlyNode, isStateTreeNode, types } from "../src";
+import { flow, getSnapshot, getType, isReadOnlyNode, isStateTreeNode, types } from "../src";
 import { ClassModel, action, register, view, volatile } from "../src/class-model";
 import { $identifier } from "../src/symbols";
 import { NamedThingClass, TestClassModel } from "./fixtures/TestClassModel";
@@ -630,5 +630,25 @@ describe("class models", () => {
       expect(set.has(1)).toBeTruthy();
       expect(set.has(3)).toBeFalsy();
     });
+  });
+
+  test("snapshots of optional class models don't trigger typescript too-deep errors", () => {
+    @register
+    class Child extends ClassModel({}) {}
+
+    const ChildSnapshot: SnapshotIn<typeof Child> = {};
+
+    // export const DefaultNominalServerContract = ServerContract;
+    const DefaultedChild = types.optional(Child, ChildSnapshot);
+
+    @register
+    class Parent extends ClassModel({
+      child: DefaultedChild,
+    }) {}
+
+    const parent = Parent.create();
+
+    const _snapshot = getSnapshot(parent);
+    const _childSnapshot = getSnapshot(parent.child);
   });
 });

--- a/spec/fixtures/OptionalClassModel.ts
+++ b/spec/fixtures/OptionalClassModel.ts
@@ -1,0 +1,26 @@
+import type { SnapshotIn } from "../../src";
+import { ClassModel, getSnapshot, register, types } from "../../src";
+
+@register
+export class Child extends ClassModel({
+  name: types.string,
+}) {}
+
+export const ChildSnapshot: SnapshotIn<typeof Child> = { name: "hello" };
+
+// export const DefaultNominalServerContract = ServerContract;
+export const DefaultedChild = types.optional(Child, ChildSnapshot);
+
+@register
+export class Parent extends ClassModel({
+  child: DefaultedChild,
+}) {}
+
+export const parent = Parent.create();
+
+const _snapshot = getSnapshot(parent);
+const _childSnapshot = getSnapshot(parent.child);
+type t = typeof parent.child;
+
+const createdChild = DefaultedChild.create();
+const _createdChildSnapshot = getSnapshot(createdChild);

--- a/spec/getSnapshot.spec.ts
+++ b/spec/getSnapshot.spec.ts
@@ -1,0 +1,102 @@
+import type { IsExact } from "conditional-type-checks";
+import { assert } from "conditional-type-checks";
+import type { SnapshotOut } from "../src";
+import { types } from "../src";
+import { getSnapshot } from "../src/api";
+import { TestClassModel } from "./fixtures/TestClassModel";
+import { NamedThing, TestModel, TestModelSnapshot } from "./fixtures/TestModel";
+
+describe("getSnapshot", () => {
+  test("returns the expected snapshot for a read-only instance", () => {
+    const m = TestModel.createReadOnly(TestModelSnapshot);
+    expect(getSnapshot(m)).toEqual(expect.objectContaining(TestModelSnapshot));
+  });
+
+  test("returns the expected snapshot for an observable class model instance", () => {
+    const m = TestClassModel.create(TestModelSnapshot);
+    const snapshot = getSnapshot(m);
+    assert<IsExact<typeof snapshot.bool, boolean>>(true);
+    expect(snapshot).toEqual(expect.objectContaining(TestModelSnapshot));
+  });
+
+  test("returns the expected snapshot for a read only class model instance", () => {
+    const m = TestClassModel.createReadOnly(TestModelSnapshot);
+    const snapshot = getSnapshot(m);
+    assert<IsExact<typeof snapshot.bool, boolean>>(true);
+    expect(getSnapshot(m)).toEqual(expect.objectContaining(TestModelSnapshot));
+  });
+
+  test("returns a plain object for QuickMap", () => {
+    const now = new Date();
+    const m = types.map(types.frozen()).createReadOnly({ A: now, B: "test" });
+    expect(getSnapshot(m)).toEqual({ A: now.getTime(), B: "test" });
+  });
+
+  test("returns a number for types.Date", () => {
+    const now = new Date();
+    const m = types.Date.createReadOnly(now);
+    expect(getSnapshot(m)).toEqual(now.getTime());
+  });
+
+  test("returns undefined for a maybeNull(frozen)", () => {
+    const m = types.maybeNull(types.frozen()).createReadOnly();
+    expect(getSnapshot(m)).toEqual(undefined);
+  });
+
+  test("returns a string for reference types", () => {
+    const m = types.model({
+      testModels: types.array(TestModel),
+      ref: types.reference(NamedThing),
+      safeRef1: types.safeReference(NamedThing),
+      safeRef2: types.safeReference(NamedThing),
+    });
+
+    const instance = m.createReadOnly({
+      testModels: [
+        { bool: true, nested: { key: "a", name: "a 1" }, frozen: { test: "string" } },
+        { bool: false, nested: { key: "b", name: "b 2" }, frozen: { test: "string" } },
+      ],
+      ref: "b",
+      safeRef1: "x",
+      safeRef2: "a",
+    });
+
+    expect(instance.ref.name).toEqual("b 2");
+    expect(getSnapshot(instance).ref).toEqual("b");
+    expect(getSnapshot(instance).safeRef1).toBeUndefined();
+    expect(getSnapshot(instance).safeRef2).toEqual("a");
+  });
+
+  function verifySnapshot(snapshot: any) {
+    expect(snapshot).toEqual(expect.objectContaining(TestModelSnapshot));
+    expect(snapshot.map.test_key.key).toEqual("test_key");
+  }
+
+  test("snapshots an observable node model instance", () => {
+    const instance = TestModel.create(TestModelSnapshot);
+    const snapshot = getSnapshot(instance);
+    verifySnapshot(snapshot);
+    assert<IsExact<typeof snapshot.map.test_key, SnapshotOut<typeof NamedThing>>>(true);
+  });
+
+  test("snapshots an readonly node model instance", () => {
+    const instance = TestModel.createReadOnly(TestModelSnapshot);
+    const snapshot = getSnapshot(instance);
+    verifySnapshot(snapshot);
+    assert<IsExact<typeof snapshot.map.test_key, SnapshotOut<typeof NamedThing>>>(true);
+  });
+
+  test("snapshots an observable class model instance", () => {
+    const instance = TestClassModel.create(TestModelSnapshot);
+    const snapshot = getSnapshot(instance);
+    verifySnapshot(snapshot);
+    assert<IsExact<typeof snapshot.map.test_key, SnapshotOut<typeof NamedThing>>>(true);
+  });
+
+  test("snapshots an readonly class model instance", () => {
+    const instance = TestClassModel.createReadOnly(TestModelSnapshot);
+    const snapshot = getSnapshot(instance);
+    verifySnapshot(snapshot);
+    assert<IsExact<typeof snapshot.map.test_key, SnapshotOut<typeof NamedThing>>>(true);
+  });
+});

--- a/spec/maybe.spec.ts
+++ b/spec/maybe.spec.ts
@@ -1,0 +1,56 @@
+import type { IsExact } from "conditional-type-checks";
+import { assert } from "conditional-type-checks";
+import type { Instance } from "../src";
+import { types } from "../src";
+import { TestClassModel } from "./fixtures/TestClassModel";
+import { TestModel, TestModelSnapshot } from "./fixtures/TestModel";
+
+describe("maybe", () => {
+  const maybeType = types.maybe(types.string);
+
+  test("can create a read-only instance", () => {
+    expect(maybeType.createReadOnly()).toEqual(undefined);
+    expect(maybeType.createReadOnly(undefined)).toEqual(undefined);
+    expect(maybeType.createReadOnly("value 2")).toEqual("value 2");
+  });
+
+  test("can be verified with is", () => {
+    expect(maybeType.is(undefined)).toEqual(true);
+    expect(maybeType.is("not testing")).toEqual(true);
+    expect(maybeType.is(null)).toEqual(false);
+    expect(maybeType.is(true)).toEqual(false);
+    expect(maybeType.is({})).toEqual(false);
+  });
+
+  test("instances of maybe node models distribute", () => {
+    const maybeNodeType = types.maybe(TestModel);
+    const instance = maybeNodeType.create(TestModelSnapshot);
+    expect(instance).toBeTruthy();
+    assert<IsExact<typeof instance, Instance<typeof TestModel> | undefined>>(true);
+  });
+
+  test("instances of maybe class models can be asserted", () => {
+    const maybeClassModelType = types.maybe(TestClassModel);
+    const instance = maybeClassModelType.create(TestModelSnapshot);
+    expect(instance).toBeTruthy();
+    assert<IsExact<typeof instance, Instance<typeof TestClassModel> | undefined>>(true);
+  });
+});
+
+describe("maybeNull", () => {
+  const maybeNullType = types.maybeNull(types.string);
+
+  test("can create a read-only instance", () => {
+    expect(maybeNullType.createReadOnly(null)).toEqual(null);
+    expect(maybeNullType.createReadOnly(undefined)).toEqual(null);
+    expect(maybeNullType.createReadOnly("value 2")).toEqual("value 2");
+  });
+
+  test("can be verified with is", () => {
+    expect(maybeNullType.is(null)).toEqual(true);
+    expect(maybeNullType.is(undefined)).toEqual(true);
+    expect(maybeNullType.is("not testing")).toEqual(true);
+    expect(maybeNullType.is(true)).toEqual(false);
+    expect(maybeNullType.is({})).toEqual(false);
+  });
+});

--- a/spec/simple.spec.ts
+++ b/spec/simple.spec.ts
@@ -64,42 +64,6 @@ describe("late", () => {
   });
 });
 
-describe("maybe", () => {
-  const maybeType = types.maybe(types.string);
-
-  test("can create a read-only instance", () => {
-    expect(maybeType.createReadOnly()).toEqual(undefined);
-    expect(maybeType.createReadOnly(undefined)).toEqual(undefined);
-    expect(maybeType.createReadOnly("value 2")).toEqual("value 2");
-  });
-
-  test("can be verified with is", () => {
-    expect(maybeType.is(undefined)).toEqual(true);
-    expect(maybeType.is("not testing")).toEqual(true);
-    expect(maybeType.is(null)).toEqual(false);
-    expect(maybeType.is(true)).toEqual(false);
-    expect(maybeType.is({})).toEqual(false);
-  });
-});
-
-describe("maybeNull", () => {
-  const maybeNullType = types.maybeNull(types.string);
-
-  test("can create a read-only instance", () => {
-    expect(maybeNullType.createReadOnly(null)).toEqual(null);
-    expect(maybeNullType.createReadOnly(undefined)).toEqual(null);
-    expect(maybeNullType.createReadOnly("value 2")).toEqual("value 2");
-  });
-
-  test("can be verified with is", () => {
-    expect(maybeNullType.is(null)).toEqual(true);
-    expect(maybeNullType.is(undefined)).toEqual(true);
-    expect(maybeNullType.is("not testing")).toEqual(true);
-    expect(maybeNullType.is(true)).toEqual(false);
-    expect(maybeNullType.is({})).toEqual(false);
-  });
-});
-
 describe("literal", () => {
   const literal = types.literal("testing");
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -39,6 +39,7 @@ import type {
   IStateTreeNode,
   IType,
   Instance,
+  SnapshotIn,
 } from "./types";
 
 export {
@@ -207,9 +208,9 @@ export function resolveIdentifier<T extends IAnyModelType>(
   throw new Error("not yet implemented");
 }
 
-export const applySnapshot = <C>(target: IStateTreeNode<IType<C, any, any>>, snapshot: C): void => {
+export const applySnapshot = <T extends IAnyType>(target: IStateTreeNode<T>, snapshot: SnapshotIn<T>): void => {
   if (mstIsStateTreeNode(target)) {
-    mstApplySnapshot<C>(target as MSTStateTreeNode, snapshot);
+    mstApplySnapshot(target as MSTStateTreeNode, snapshot);
     return;
   }
 

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -4,14 +4,14 @@ import { getType, isModelType, isReferenceType, isStateTreeNode } from "./api";
 import { QuickArray } from "./array";
 import { QuickMap } from "./map";
 import { $identifier } from "./symbols";
-import type { IClassModelType, IStateTreeNode, IType } from "./types";
+import type { IAnyType, IStateTreeNode, SnapshotOut } from "./types";
 
-export function getSnapshot<S>(value: IStateTreeNode<IType<any, S, any>> | IStateTreeNode<IClassModelType<any, any, S>>): S {
+export function getSnapshot<T extends IAnyType>(value: IStateTreeNode<T>): SnapshotOut<T> {
   if (mstIsStateTreeNode(value)) {
-    return mstGetSnapshot<S>(value as MSTStateTreeNode);
+    return mstGetSnapshot(value as MSTStateTreeNode);
   }
 
-  return snapshot(value) as S;
+  return snapshot(value) as SnapshotOut<T>;
 }
 
 const snapshot = (value: any): unknown => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -250,7 +250,8 @@ export type IStateTreeNode<T extends IAnyType = IAnyType> = {
   readonly [$type]?: [T] | [any];
 };
 
-export type StateTreeNode<T, IT extends IAnyType> = T extends object ? T & IStateTreeNode<IT> : T;
+export type StateTreeNode<T, IT extends IAnyType> = T extends { [$type]?: any } ? T : T extends object ? T & IStateTreeNode<IT> : T;
+
 export type IAnyStateTreeNode = StateTreeNode<any, IAnyType>;
 
 /** The incoming properties passed to a types.model() or ClassModel() model factory */


### PR DESCRIPTION
This fixes a big issue after adding class models where ITypes wrapping class models didn't correctly instantiate. It all stems from IStateTreeNode -- the existing types use it to decorate any ole object with the `$type` it is of. This facilitates grabbing the type at runtime for API functions like `getType`, and for grabbing the type at type time to power type safety in the API for things like `getSnapshot` etc.

IStateTreeNode is thusly key, and it used to be that everything that was intantiated could be wrapped in an `IStateTreeNode` wrapper pretty easily. We need to keep doing this for IMaybeType and IReferenceType and the other ITypes which wrap some other inner type, but we don't want to do it to class models, which define their own `$type` property, and break things if extended with `& { [$type]: ... }`.

Making IStateTreeNode not extend the type if the type already has a `$type` fixes static typing. Jesus.
