### PR TITLE
Add a facility for running actions that only touch volatiles on readonly instances

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -70,7 +70,7 @@ export {
   typecheck,
   walk,
 } from "mobx-state-tree";
-export { ClassModel, action, register, view } from "./class-model";
+export { ClassModel, action, volatileAction, register, view } from "./class-model";
 export { getSnapshot } from "./snapshot";
 
 export const isType = (value: any): value is IAnyType => {


### PR DESCRIPTION
We have a few volatile properties Gadget-side that we set after instantiation. The setters for these props work like any others: we decorate the setter with `@action` so that it can mess with stuff and is present on both the observable and readonly instance type. Because this setter is a normal action, we are forced to use observable instances of these objects. In some cases, this is a big performance penalty -- the *only* prop we want to ever change is a volatile one, and the snapshot bit really is readonly. So, I think we should introduce an escape hatch for "i know what I am doing", and allow a select few actions to actually be invoked on readonly instances.

The rule I propose is that these actions are only allowed to muck with volatiles. Volatiles are for the weird, not-snapshot, never persisted state, and it seems like a good alignment to make volatiles settable on readonly instances so you can use them for tracking references to stuff for instances that are otherwise readonly. So, this new kind of action is still an action, but I called it `@volatileAction`.

The only-touch-volatiles rule is only enforced right now by convention -- `@action` will throw but `@volatileAction` won't, and within the function, you can do whatever you want. I think that any enforcement will add performance overhead that I don't really care to add right now, so I think we should start with hoping the convention is clear enough.

The specific piece I want to use this for is the `setGeneratingParent` action within Gadget, where we hop across MST roots for analysis nice and easy. The object which has a generating parent is truly readonly, we just need this annoying runtime reference for stuff.
