### PR TITLE
Allow union type instantiation to be faster by specifying a discriminator property

### DIFF
--- a/spec/simple.spec.ts
+++ b/spec/simple.spec.ts
@@ -1,4 +1,4 @@
-import { getSnapshot, types } from "../src";
+import { types } from "../src";
 
 describe("boolean", () => {
   test("can create a read-only instance", () => {
@@ -61,45 +61,6 @@ describe("literal", () => {
     expect(literal.is(null)).toEqual(false);
     expect(literal.is(true)).toEqual(false);
     expect(literal.is({})).toEqual(false);
-  });
-});
-
-describe("union", () => {
-  const unionType = types.union(types.literal("value 1"), types.literal("value 2"));
-
-  test("can create a read-only instance", () => {
-    expect(unionType.createReadOnly("value 1")).toEqual("value 1");
-    expect(unionType.createReadOnly("value 2")).toEqual("value 2");
-    expect(() => unionType.createReadOnly("value 3" as any)).toThrow();
-  });
-
-  test("can create an eager, read-only instance", () => {
-    const unionType = types.lazyUnion(types.literal("value 1"), types.literal("value 2"));
-    expect(unionType.createReadOnly("value 1")).toEqual("value 1");
-    expect(unionType.createReadOnly("value 2")).toEqual("value 2");
-    expect(() => unionType.createReadOnly("value 3" as any)).toThrow();
-  });
-
-  test("can be verified with is", () => {
-    expect(unionType.is("value 1")).toEqual(true);
-    expect(unionType.is("value 2")).toEqual(true);
-    expect(unionType.is("value 3")).toEqual(false);
-    expect(unionType.is(null)).toEqual(false);
-    expect(unionType.is(true)).toEqual(false);
-    expect(unionType.is({})).toEqual(false);
-  });
-
-  test("can create a union of model types", () => {
-    const modelTypeA = types.model({ x: types.string });
-    const modelTypeB = types.model({ y: types.number });
-    const unionType = types.union(modelTypeA, modelTypeB);
-    const unionInstance = unionType.createReadOnly({ x: "test" });
-
-    expect(getSnapshot(unionInstance)).toEqual(
-      expect.objectContaining({
-        x: "test",
-      })
-    );
   });
 });
 

--- a/spec/union.spec.ts
+++ b/spec/union.spec.ts
@@ -1,0 +1,158 @@
+import { getSnapshot, types } from "../src";
+import { create } from "./helpers";
+
+describe("union", () => {
+  const unionType = types.union(types.literal("value 1"), types.literal("value 2"));
+
+  test("can be verified with is", () => {
+    expect(unionType.is("value 1")).toEqual(true);
+    expect(unionType.is("value 2")).toEqual(true);
+    expect(unionType.is("value 3")).toEqual(false);
+    expect(unionType.is(null)).toEqual(false);
+    expect(unionType.is(true)).toEqual(false);
+    expect(unionType.is({})).toEqual(false);
+  });
+
+  describe.each([
+    ["readonly", true],
+    ["observable", false],
+  ])("%s nodes", (_, readonly) => {
+    test("can create an instance", () => {
+      expect(create(unionType, "value 1", readonly)).toEqual("value 1");
+      expect(create(unionType, "value 2", readonly)).toEqual("value 2");
+      expect(() => create(unionType, "value 3" as any, readonly)).toThrow();
+    });
+
+    test("can create an eager, read-only instance", () => {
+      const unionType = types.lazyUnion(types.literal("value 1"), types.literal("value 2"));
+      expect(create(unionType, "value 1", readonly)).toEqual("value 1");
+      expect(create(unionType, "value 2", readonly)).toEqual("value 2");
+      expect(() => create(unionType, "value 3" as any, readonly)).toThrow();
+    });
+
+    test("can create a union of model types", () => {
+      const modelTypeA = types.model({ x: types.string });
+      const modelTypeB = types.model({ y: types.number });
+      const unionType = types.union(modelTypeA, modelTypeB);
+      const unionInstance = create(unionType, { x: "test" }, readonly);
+
+      expect(getSnapshot(unionInstance)).toEqual(
+        expect.objectContaining({
+          x: "test",
+        })
+      );
+    });
+
+    test("nested unions", () => {
+      const one = types.union(types.literal("A"), types.literal("B"));
+      const two = types.union(types.literal("C"), types.literal("D"));
+      const Union = types.union(one, two);
+
+      const aInstance = create(Union, "A", readonly);
+      expect(aInstance).toEqual("A");
+
+      const dInstance = create(Union, "D", readonly);
+      expect(dInstance).toEqual("D");
+    });
+
+    describe("with an explicit dispatcher option", () => {
+      test("can use a dispatcher", () => {
+        const Apple = types.model({ color: types.string });
+        const Banana = types.model({ ripeness: types.number });
+        const Union = types.union(
+          {
+            dispatcher: (snapshot: any) => {
+              if (snapshot.color) {
+                return Apple;
+              } else {
+                return Banana;
+              }
+            },
+          },
+          Apple,
+          Banana
+        );
+
+        const appleInstance = create(Union, { color: "red" }, readonly);
+        expect(Apple.is(appleInstance)).toBeTruthy();
+        expect(Banana.is(appleInstance)).toBeFalsy();
+
+        const bananaInstance = create(Union, { ripeness: 2 }, readonly);
+        expect(Apple.is(bananaInstance)).toBeFalsy();
+        expect(Banana.is(bananaInstance)).toBeTruthy();
+      });
+    });
+
+    describe("with an explicit discriminator property", () => {
+      test("can use a literal discriminator", () => {
+        const Apple = types.model({ type: types.literal("apple"), color: types.string });
+        const Banana = types.model({ type: types.literal("banana"), ripeness: types.number });
+        const Union = types.union({ discriminator: "type" }, Apple, Banana);
+
+        const appleInstance = create(Union, { type: "apple", color: "red" }, readonly);
+        expect(Apple.is(appleInstance)).toBeTruthy();
+        expect(Banana.is(appleInstance)).toBeFalsy();
+
+        const bananaInstance = create(Union, { type: "banana", ripeness: 2 }, readonly);
+        expect(Apple.is(bananaInstance)).toBeFalsy();
+        expect(Banana.is(bananaInstance)).toBeTruthy();
+      });
+
+      test("can use an optional literal discriminator", () => {
+        const Apple = types.model({ type: types.optional(types.literal("apple"), "apple"), color: types.string });
+        const Banana = types.model({ type: types.optional(types.literal("banana"), "banana"), ripeness: types.number });
+        const Union = types.union({ discriminator: "type" }, Apple, Banana);
+
+        const appleInstance = create(Union, { type: "apple", color: "red" }, readonly);
+        expect(Apple.is(appleInstance)).toBeTruthy();
+        expect(Banana.is(appleInstance)).toBeFalsy();
+
+        const bananaInstance = create(Union, { type: "banana", ripeness: 2 }, readonly);
+        expect(Apple.is(bananaInstance)).toBeFalsy();
+        expect(Banana.is(bananaInstance)).toBeTruthy();
+      });
+
+      test("does not get an error when passing a snapshot that doesn't have a value for the discriminator property", () => {
+        const Apple = types.model({ type: types.optional(types.literal("apple"), "apple"), color: types.string });
+        const Banana = types.model({ type: types.optional(types.literal("banana"), "banana"), ripeness: types.number });
+        const Union = types.union({ discriminator: "type" }, Apple, Banana);
+
+        const apple = create(Union, { color: "red" }, readonly);
+        expect(Apple.is(apple)).toBeTruthy();
+      });
+
+      test("can use an literal discriminators within nested unions", () => {
+        const Apple = types.model({ type: types.optional(types.literal("apple"), "apple"), color: types.string });
+        const Banana = types.model({ type: types.optional(types.literal("banana"), "banana"), ripeness: types.number });
+        const InnerUnion = types.union({ discriminator: "type" }, Apple, Banana);
+        const Pear = types.model({ type: types.optional(types.literal("pear"), "pear"), species: types.string });
+        const Union = types.union({ discriminator: "type" }, InnerUnion, Pear);
+
+        const appleInstance = create(Union, { type: "apple", color: "red" }, readonly);
+        expect(Apple.is(appleInstance)).toBeTruthy();
+        expect(Banana.is(appleInstance)).toBeFalsy();
+        expect(Pear.is(appleInstance)).toBeFalsy();
+
+        const bananaInstance = create(Union, { type: "banana", ripeness: 2 }, readonly);
+        expect(Apple.is(bananaInstance)).toBeFalsy();
+        expect(Banana.is(bananaInstance)).toBeTruthy();
+        expect(Pear.is(bananaInstance)).toBeFalsy();
+
+        const pearInstance = create(Union, { type: "pear", species: "anjou" }, readonly);
+        expect(Apple.is(pearInstance)).toBeFalsy();
+        expect(Banana.is(pearInstance)).toBeFalsy();
+        expect(Pear.is(pearInstance)).toBeTruthy();
+      });
+    });
+  });
+
+  test("gets an error when passing a snapshot that has an unrecognized value for the discriminator property", () => {
+    const Apple = types.model({ type: types.optional(types.literal("apple"), "apple"), color: types.string });
+    const Banana = types.model({ type: types.optional(types.literal("banana"), "banana"), ripeness: types.number });
+    const Union = types.union({ discriminator: "type" }, Apple, Banana);
+
+    expect(() => create(Union, { type: "pear" } as any, true)).toThrowErrorMatchingInlineSnapshot(
+      `"Discriminator property value \`pear\` for property \`type\` on incoming snapshot didn't correspond to a type. Options: apple, banana. Snapshot was \`{"type":"pear"}\`"`
+    );
+  });
+});

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -471,3 +471,7 @@ function getPropertyDescriptor(obj: any, property: string) {
   }
   return null;
 }
+
+export const isClassModel = (type: IAnyType): type is IClassModelType<any, any, any> => {
+  return (type as any).isMQTClassModel;
+};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,3 +3,6 @@ export class CantRunActionError extends Error {}
 
 /** Thrown when an invalid registration is passed to the class model register function */
 export class RegistrationError extends Error {}
+
+/** Thrown when a type in a union can't be used for discrimination because the value of the descriminator property can't be determined at runtime */
+export class InvalidDiscriminatorError extends Error {}

--- a/src/optional.ts
+++ b/src/optional.ts
@@ -13,7 +13,7 @@ import type {
 
 export type DefaultFuncOrValue<T extends IAnyType> = T["InputType"] | T["OutputType"] | (() => CreateTypes<T>);
 
-class OptionalType<T extends IAnyType, OptionalValues extends [ValidOptionalValue, ...ValidOptionalValue[]]> extends BaseType<
+export class OptionalType<T extends IAnyType, OptionalValues extends [ValidOptionalValue, ...ValidOptionalValue[]]> extends BaseType<
   T["InputType"] | OptionalValues[number],
   T["OutputType"],
   InstanceWithoutSTNTypeForType<T>

--- a/src/simple.ts
+++ b/src/simple.ts
@@ -80,7 +80,7 @@ export class NullType extends BaseType<null, null, null> {
   }
 }
 
-class LiteralType<T extends Primitives> extends SimpleType<T> {
+export class LiteralType<T extends Primitives> extends SimpleType<T> {
   constructor(readonly value: T) {
     super(typeof value, types.literal<T>(value));
   }

--- a/src/union.ts
+++ b/src/union.ts
@@ -1,26 +1,132 @@
-import type { UnionOptions } from "mobx-state-tree";
+import type { IType, UnionOptions as MSTUnionOptions } from "mobx-state-tree";
 import { types as mstTypes } from "mobx-state-tree";
 import { BaseType } from "./base";
-import { ensureRegistered } from "./class-model";
+import { ensureRegistered, isClassModel } from "./class-model";
 import type { IAnyType, InstanceWithoutSTNTypeForType, InstantiateContext, IUnionType } from "./types";
+import { OptionalType } from "./optional";
+import { isModelType, isType } from "./api";
+import { LiteralType } from "./simple";
+import { InvalidDiscriminatorError } from "./errors";
+
+export type ITypeDispatcher = (snapshot: any) => IAnyType;
+
+export interface UnionOptions extends Omit<MSTUnionOptions, "dispatcher"> {
+  /**
+   * Instantiating unions can be kind of slow in general as we have to test each of the possible types against an incoming snapshot
+   *
+   * For quickly looking up which of the union types is the correct one for an incoming snapshot, you can set this to one of the properties that is present on all the incoming types, and union instantiation will use it to avoid the type scan.
+   **/
+  discriminator?: string;
+
+  /** Function for customizing the union's selection of which type to use for a snapshot */
+  dispatcher?: ITypeDispatcher;
+}
+
+const emptyContext: InstantiateContext = {
+  referenceCache: new Map(),
+  referencesToResolve: [],
+};
+
+type DiscriminatorTypeMap = Record<string, IAnyType>;
+
+/**
+ * Build a map of runtime values to the type that should be constructed for snapshots with that value at the `discriminator` property
+ **/
+const buildDiscriminatorTypeMap = (types: IAnyType[], discriminator: string) => {
+  const map: DiscriminatorTypeMap = {};
+
+  const setMapValue = (type: IAnyType, instantiateAsType: IAnyType): any => {
+    if (type instanceof UnionType) {
+      // support nested unions by recursing into their types, using the same discriminator
+      for (const innerUnionType of type.types) {
+        setMapValue(innerUnionType, innerUnionType);
+      }
+    } else if (isClassModel(type) || isModelType(type)) {
+      setMapValue(type.properties[discriminator], instantiateAsType);
+    } else if (type instanceof OptionalType) {
+      const value = type.instantiate(undefined, emptyContext);
+      map[value] = instantiateAsType;
+    } else if (type instanceof LiteralType) {
+      map[type.value] = instantiateAsType;
+    } else {
+      throw new InvalidDiscriminatorError(
+        `Can't use the discriminator property \`${discriminator}\` on the type \`${type}\` as it is of a type who's value can't be determined at union creation time.`
+      );
+    }
+  };
+
+  // figure out what the runtime value of the discriminator property is for each type
+  for (const type of types) {
+    setMapValue(type, type);
+  }
+
+  return map;
+};
 
 class UnionType<Types extends IAnyType[]> extends BaseType<
   Types[number]["InputType"],
   Types[number]["OutputType"],
   InstanceWithoutSTNTypeForType<Types[number]>
 > {
-  constructor(private types: Types, readonly options?: UnionOptions) {
-    super(options ? mstTypes.union(options, ...types.map((x) => x.mstType)) : mstTypes.union(...types.map((x) => x.mstType)));
+  readonly dispatcher?: ITypeDispatcher;
+
+  constructor(readonly types: Types, readonly options: UnionOptions = {}) {
+    let dispatcher: ITypeDispatcher | undefined = undefined;
+
+    if (options?.dispatcher) {
+      dispatcher = options.dispatcher;
+    } else if (options?.discriminator) {
+      const discriminatorToTypeMap = buildDiscriminatorTypeMap(types, options.discriminator);
+
+      // build a dispatcher that looks up the type based on the discriminator value from the snapshot
+      dispatcher = (snapshot) => {
+        const discriminatorValue = snapshot[options.discriminator!];
+        let type;
+        if (discriminatorValue) {
+          type = discriminatorToTypeMap[discriminatorValue];
+        } else {
+          // if no discriminator value is present, fallback to the slow way
+          type = types.find((ty) => ty.is(snapshot));
+        }
+        if (!type) {
+          throw new TypeError(
+            `Discriminator property value \`${discriminatorValue}\` for property \`${
+              options.discriminator
+            }\` on incoming snapshot didn't correspond to a type. Options: ${Object.keys(discriminatorToTypeMap).join(
+              ", "
+            )}. Snapshot was \`${JSON.stringify(snapshot)}\``
+          );
+        }
+
+        return type;
+      };
+    }
+
+    super(
+      mstTypes.union(
+        { ...options, dispatcher: dispatcher ? (snapshot) => dispatcher!(snapshot).mstType : undefined },
+        ...types.map((x) => x.mstType)
+      )
+    );
+
+    this.dispatcher = dispatcher;
   }
 
   instantiate(snapshot: this["InputType"], context: InstantiateContext): this["InstanceType"] {
-    const type = this.types.find((ty) => ty.is(snapshot));
+    let type: Types[number] | undefined;
+    if (this.dispatcher) {
+      type = this.dispatcher(snapshot);
+    } else {
+      type = this.types.find((ty) => ty.is(snapshot));
+    }
+
     if (!type) {
       // try to get MST's nice error formatting by having it create the object from this snapshot
       this.mstType.create(snapshot);
       // if that doesn't throw, throw our own error
       throw new Error("couldn't find valid type from union for given snapshot");
     }
+
     return type.instantiate(snapshot, context);
   }
 
@@ -30,12 +136,24 @@ class UnionType<Types extends IAnyType[]> extends BaseType<
   }
 }
 
-export const union = <Types extends [IAnyType, ...IAnyType[]]>(...types: Types): IUnionType<Types> => {
-  types.forEach(ensureRegistered);
-  return new UnionType(types);
-};
+export function union<Types extends [IAnyType, ...IAnyType[]]>(...types: Types): IUnionType<Types>;
+export function union<Types extends [IAnyType, ...IAnyType[]]>(options: UnionOptions, ...types: Types): IUnionType<Types>;
+export function union<Types extends [IAnyType, ...IAnyType[]]>(
+  optionsOrType: UnionOptions | Types[number],
+  ...types: Types
+): IUnionType<Types> {
+  let options = undefined;
+  if (isType(optionsOrType)) {
+    types.unshift(optionsOrType);
+  } else {
+    options = optionsOrType;
+  }
 
-export const lazyUnion = <Types extends [IAnyType, ...IAnyType[]]>(...types: Types): IUnionType<Types> => {
+  types.forEach(ensureRegistered);
+  return new UnionType(types, options);
+}
+
+export function lazyUnion<Types extends [IAnyType, ...IAnyType[]]>(...types: Types): IUnionType<Types> {
   types.forEach(ensureRegistered);
   return new UnionType(types, { eager: false });
-};
+}


### PR DESCRIPTION
Gadget side, we instantiate a lot of unions that have many elements. Both MQT (or MST) have to take an incoming snapshot and figure out which element of the union is the right one to instantiate and return for the union. Both of them have a pretty naive algorithm for doing this: take each element and check the snapshot against it, returning the first union element which does. This means a LOT of `type.is` checks, where each type in the union is compared against the snapshot. These type.is checks basically do a full instantiation under the hood -- there's no fancy fast path for `.is` for a lot of types, there's just running the runtime code that would boot an instance, and seeing if it fails.

This works in the general case but has gotten really slow in Gadget, specifically for the FieldConfig enum. It has a lot of elements, and each element's type is complicated-ish such that it takes a little bit of time to check with `.is`.

Our snapshots for this type have a really easy to get at `"type": "StringConfig"` property on them though that allows us to discriminate between the union elements super easily. We added this a long time ago for typescript discriminated unions at type type, but, I think we can use this at runtime too for a much faster path for instantiation. MST already has support for a custom union type "dispatcher", that returns the right type to use for instantiation given a snapshot. This PR adds support for that, and then adds a macro of sorts on top that does type dispatching using a discriminating property. We expect all the types in the union to have a value for this property we can inspect at the time the union is defined, and then we build a map from the value of the discriminator to the type. When a snapshot comes in, we look up the value of the snapshot's discriminator property within the map.

For the schema generation benchmark in Gadget on `main`:
```
{
  sampleCount: 500,
  failedCount: 0,
  histogram: Histogram {
    min: 66,
    max: 318,
    mean: 92.966,
    exceeds: 0,
    stddev: 43.543551118391804,
    count: 500,
    percentiles: SafeMap(11) [Map] {
      0 => 66,
      50 => 80,
      75 => 88,
      87.5 => 105,
      93.75 => 208,
      96.875 => 245,
      98.4375 => 263,
      99.21875 => 275,
      99.609375 => 317,
      99.8046875 => 318,
      100 => 318
    }
  }
}
```

For the schema generation benchmark with this prereleased branch:

```
{
  sampleCount: 500,
  failedCount: 0,
  histogram: Histogram {
    min: 38,
    max: 266,
    mean: 50.092,
    exceeds: 0,
    stddev: 23.49552161583139,
    count: 500,
    percentiles: SafeMap(11) [Map] {
      0 => 38,
      50 => 46,
      75 => 51,
      87.5 => 55,
      93.75 => 60,
      96.875 => 71,
      98.4375 => 133,
      99.21875 => 254,
      99.609375 => 260,
      99.8046875 => 266,
      100 => 266
    }
  }
}
```

Almost a 50% improvement! Woop woop!