### PR TITLE
Faster instantiation

### DIFF
--- a/spec/api.spec.ts
+++ b/spec/api.spec.ts
@@ -108,7 +108,7 @@ describe("isRoot", () => {
   });
 
   test("returns true for root read only class model instances", () => {
-    const m = new TestClassModel(TestModelSnapshot);
+    const m = TestClassModel.createReadOnly(TestModelSnapshot);
     expect(isRoot(m)).toEqual(true);
     expect(isRoot(m.nested)).toEqual(false);
   });

--- a/spec/api.spec.ts
+++ b/spec/api.spec.ts
@@ -46,7 +46,7 @@ describe("getParentOfType", () => {
   });
 
   test("returns the proper root for class model instance", () => {
-    const m = new TestClassModel(TestModelSnapshot);
+    const m = TestClassModel.createReadOnly(TestModelSnapshot);
     expect(() => getParentOfType(m, TestClassModel)).toThrow();
     const parent = getParentOfType(m.nested, TestClassModel);
     expect(parent).toEqual(m);

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,5 +1,5 @@
 import { isStateTreeNode, types } from "mobx-state-tree";
-import { BaseType, setParent, setType } from "./base";
+import { BaseType, setParent } from "./base";
 import { ensureRegistered } from "./class-model";
 import { $readOnly, $type } from "./symbols";
 import type { IAnyStateTreeNode, IAnyType, IArrayType, IMSTArray, Instance, InstantiateContext } from "./types";
@@ -76,7 +76,12 @@ class ArrayType<T extends IAnyType> extends BaseType<Array<T["InputType"]> | und
       });
     }
 
-    setType(array, this);
+    Reflect.defineProperty(array, $type, {
+      value: this,
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    });
 
     return array as this["InstanceType"];
   }

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,5 +1,5 @@
 import { isStateTreeNode, types } from "mobx-state-tree";
-import { BaseType, setParent } from "./base";
+import { BaseType, setEnv, setParent } from "./base";
 import { ensureRegistered } from "./class-model";
 import { $parent, $readOnly, $type } from "./symbols";
 import type { IAnyStateTreeNode, IAnyType, IArrayType, IMSTArray, IStateTreeNode, Instance, InstantiateContext } from "./types";
@@ -82,6 +82,8 @@ class ArrayType<T extends IAnyType> extends BaseType<Array<T["InputType"]> | und
       enumerable: false,
       writable: false,
     });
+
+    setEnv(array, context.env);
 
     return array as this["InstanceType"];
   }

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,6 +1,6 @@
 import type { IAnyType as MSTAnyType } from "mobx-state-tree";
 import { $env, $parent, $quickType, $type } from "./symbols";
-import type { IAnyStateTreeNode, IAnyType, InstantiateContext, StateTreeNode } from "./types";
+import type { IAnyStateTreeNode, IAnyType, IStateTreeNode, InstantiateContext, StateTreeNode } from "./types";
 
 export abstract class BaseType<InputType, OutputType, InstanceType> {
   readonly [$quickType] = undefined;
@@ -44,7 +44,7 @@ export abstract class BaseType<InputType, OutputType, InstanceType> {
       env,
     };
 
-    const instance = this.instantiate(snapshot, context);
+    const instance = this.instantiate(snapshot, context, null);
     for (const resolver of context.referencesToResolve) {
       resolver();
     }
@@ -54,7 +54,11 @@ export abstract class BaseType<InputType, OutputType, InstanceType> {
     return instance;
   }
 
-  abstract instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext): this["InstanceType"];
+  abstract instantiate(
+    snapshot: this["InputType"] | undefined,
+    context: InstantiateContext,
+    parent: IStateTreeNode | null
+  ): this["InstanceType"];
 }
 
 /** @hidden */

--- a/src/base.ts
+++ b/src/base.ts
@@ -58,18 +58,6 @@ export abstract class BaseType<InputType, OutputType, InstanceType> {
 }
 
 /** @hidden */
-export const setType = (value: unknown, type: IAnyType) => {
-  if (value && typeof value == "object") {
-    Reflect.defineProperty(value, $type, {
-      value: type,
-      configurable: false,
-      enumerable: false,
-      writable: false,
-    });
-  }
-};
-
-/** @hidden */
 export const setParent = (value: unknown, parent: any) => {
   if (value && typeof value == "object") {
     Reflect.defineProperty(value, $parent, {

--- a/src/base.ts
+++ b/src/base.ts
@@ -49,8 +49,6 @@ export abstract class BaseType<InputType, OutputType, InstanceType> {
       resolver();
     }
 
-    setEnv(instance, env);
-
     return instance;
   }
 

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -20,6 +20,7 @@ import type {
   IAnyClassModelType,
   IAnyType,
   IClassModelType,
+  IStateTreeNode,
   InputTypesForModelProps,
   InputsForModel,
   InstantiateContext,
@@ -78,15 +79,16 @@ class BaseClassModel {
   /** @hidden */
   readonly [$env]?: any;
   /** @hidden */
-  readonly [$parent] = null;
+  readonly [$parent]?: IStateTreeNode | null;
   /** @hidden */
   [$memos] = null;
   [$memoizedKeys] = null;
 
   constructor(
-    attrs?: InputsForModel<InputTypesForModelProps<TypesForModelPropsDeclaration<any>>>,
-    env?: any,
-    context?: InstantiateContext,
+    attrs: InputsForModel<InputTypesForModelProps<TypesForModelPropsDeclaration<any>>> | undefined,
+    env: any | undefined,
+    context: InstantiateContext | undefined,
+    parent: IStateTreeNode | null,
     /** @hidden */ hackyPreventInitialization = false
   ) {
     if (hackyPreventInitialization) {
@@ -103,6 +105,7 @@ class BaseClassModel {
     };
 
     this[$env] = env;
+    this[$parent] = parent;
     instantiateInstanceFromProperties(this, attrs, (this.constructor as any).properties, klass.mstType.identifierAttribute, context);
     initializeVolatiles(this, this, klass.volatiles);
 
@@ -278,7 +281,7 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
   klass.volatiles = mstVolatiles;
 
   // conform to the API that the other MQT types expect for creating instances
-  klass.instantiate = (snapshot, context) => new klass(snapshot, context.env, context);
+  klass.instantiate = (snapshot, context, parent) => new klass(snapshot, context.env, context, parent);
   (klass as any).is = (value: any) => value instanceof klass || klass.mstType.is(value);
   klass.create = (snapshot, env) => klass.mstType.create(snapshot, env);
   klass.createReadOnly = (snapshot, env) => new klass(snapshot, env) as any;

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -66,6 +66,9 @@ export type RegistrationTags<T> = {
   [key in keyof T]: typeof action | typeof view | VolatileDefiner;
 };
 
+/**
+ * The base-most parent class of all class models.
+ **/
 class BaseClassModel {
   static isMQTClassModel = true as const;
   static mstType: MSTIModelType<any, any>;
@@ -212,7 +215,7 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
           target = klass.prototype;
         } else {
           // hackily instantiate the class to get at the instance level properties defined by the class body (those that aren't on the prototype)
-          target = new klass({}, undefined, null, true);
+          target = new klass({}, {}, null, true);
         }
         const descriptor = getPropertyDescriptor(target, metadata.property);
 

--- a/src/custom.ts
+++ b/src/custom.ts
@@ -1,18 +1,20 @@
 import type { CustomTypeOptions } from "mobx-state-tree";
 import { types } from "mobx-state-tree";
-import { BaseType } from "./base";
-import type { InstantiateContext, IType } from "./types";
+import { BaseType, setParent } from "./base";
+import type { InstantiateContext, IStateTreeNode, IType } from "./types";
 
 class CustomType<InputType, OutputType> extends BaseType<InputType, OutputType, OutputType> {
   constructor(readonly options: CustomTypeOptions<InputType, OutputType>) {
     super(types.custom<InputType, OutputType>(options));
   }
 
-  instantiate(snapshot: InputType, _context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: InputType, _context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot === undefined) {
       throw new Error("can't initialize custom type with undefined");
     }
-    return this.options.fromSnapshot(snapshot) as this["InstanceType"];
+    const object = this.options.fromSnapshot(snapshot) as this["InstanceType"];
+    setParent(object, parent);
+    return object;
   }
 
   is(value: any): value is this["InstanceType"];

--- a/src/enumeration.ts
+++ b/src/enumeration.ts
@@ -1,13 +1,13 @@
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { IAnyStateTreeNode, InstantiateContext, ISimpleType } from "./types";
+import type { IAnyStateTreeNode, InstantiateContext, ISimpleType, IStateTreeNode } from "./types";
 
 class EnumerationType<EnumOptions extends string> extends BaseType<EnumOptions, EnumOptions, EnumOptions> {
   constructor(readonly name: string, readonly options: readonly EnumOptions[]) {
     super(types.enumeration<EnumOptions>([...options]));
   }
 
-  instantiate(snapshot: this["InputType"], _context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"], _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (typeof snapshot == "string" && this.options.includes(snapshot)) {
       return snapshot as this["InstanceType"];
     }

--- a/src/frozen.ts
+++ b/src/frozen.ts
@@ -1,13 +1,13 @@
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { InstantiateContext, ISimpleType } from "./types";
+import type { InstantiateContext, ISimpleType, IStateTreeNode } from "./types";
 
 class FrozenType<T> extends BaseType<T, T, T> {
   constructor() {
     super(types.frozen<T>());
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (typeof snapshot == "function") {
       throw new Error("frozen types can't be instantiated with functions");
     }

--- a/src/late.ts
+++ b/src/late.ts
@@ -1,7 +1,7 @@
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
 import { ensureRegistered } from "./class-model";
-import type { IAnyType, InstanceWithoutSTNTypeForType, InstantiateContext } from "./types";
+import type { IAnyType, IStateTreeNode, InstanceWithoutSTNTypeForType, InstantiateContext } from "./types";
 
 class LateType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputType"], InstanceWithoutSTNTypeForType<T>> {
   private cachedType: T | null | undefined;
@@ -10,8 +10,8 @@ class LateType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputTyp
     super(types.late<T["mstType"]>(`late(${fn.toString()})`, () => this.type?.mstType as T["mstType"]));
   }
 
-  instantiate(snapshot: this["InputType"], context: InstantiateContext): this["InstanceType"] {
-    return this.type.instantiate(snapshot, context);
+  instantiate(snapshot: this["InputType"], context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
+    return this.type.instantiate(snapshot, context, parent);
   }
 
   is(value: any): value is this["InputType"] | this["InstanceType"] {

--- a/src/map.ts
+++ b/src/map.ts
@@ -4,7 +4,17 @@ import { BaseType, setParent } from "./base";
 import { ensureRegistered } from "./class-model";
 import { getSnapshot } from "./snapshot";
 import { $readOnly, $type } from "./symbols";
-import type { CreateTypes, IAnyStateTreeNode, IAnyType, IMSTMap, IMapType, Instance, InstantiateContext, SnapshotOut } from "./types";
+import type {
+  CreateTypes,
+  IAnyStateTreeNode,
+  IAnyType,
+  IMSTMap,
+  IMapType,
+  IStateTreeNode,
+  Instance,
+  InstantiateContext,
+  SnapshotOut,
+} from "./types";
 
 export class QuickMap<T extends IAnyType> extends Map<string, Instance<T>> implements IMSTMap<T> {
   static get [Symbol.species]() {
@@ -90,15 +100,16 @@ class MapType<T extends IAnyType> extends BaseType<
     return children.every((child) => this.childrenType.is(child));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
     const map = new QuickMap<T>(this);
     if (snapshot) {
       for (const key in snapshot) {
-        const item = this.childrenType.instantiate(snapshot[key], context);
-        setParent(item, map);
+        const item = this.childrenType.instantiate(snapshot[key], context, map);
         map.set(key, item);
       }
     }
+
+    setParent(map, parent);
 
     return map as this["InstanceType"];
   }

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,6 +1,6 @@
 import type { IInterceptor, IMapDidChange, IMapWillChange, Lambda } from "mobx";
 import { isStateTreeNode, types } from "mobx-state-tree";
-import { BaseType, setParent, setType } from "./base";
+import { BaseType, setParent } from "./base";
 import { ensureRegistered } from "./class-model";
 import { getSnapshot } from "./snapshot";
 import { $readOnly, $type } from "./symbols";

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1,7 +1,15 @@
 import { types as mstTypes } from "mobx-state-tree";
 import { BaseType } from "./base";
 import { ensureRegistered } from "./class-model";
-import type { IAnyStateTreeNode, IAnyType, IMaybeNullType, IMaybeType, InstanceWithoutSTNTypeForType, InstantiateContext } from "./types";
+import type {
+  IAnyStateTreeNode,
+  IAnyType,
+  IMaybeNullType,
+  IMaybeType,
+  IStateTreeNode,
+  InstanceWithoutSTNTypeForType,
+  InstantiateContext,
+} from "./types";
 
 class MaybeType<Type extends IAnyType> extends BaseType<
   Type["InputType"] | undefined,
@@ -12,11 +20,11 @@ class MaybeType<Type extends IAnyType> extends BaseType<
     super(mstTypes.maybe(type.mstType));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot === undefined) {
       return undefined;
     }
-    return this.type.instantiate(snapshot, context);
+    return this.type.instantiate(snapshot, context, parent);
   }
 
   is(value: any): value is this["InputType"] | this["InstanceType"] {
@@ -36,16 +44,16 @@ class MaybeNullType<Type extends IAnyType> extends BaseType<
     super(mstTypes.maybeNull(type.mstType));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot === undefined || snapshot === null) {
       // Special case for things like types.frozen, or types.literal(undefined), where MST prefers the subtype over maybeNull
       if (this.type.is(snapshot)) {
-        return this.type.instantiate(snapshot, context);
+        return this.type.instantiate(snapshot, context, parent);
       }
 
       return null;
     }
-    return this.type.instantiate(snapshot, context);
+    return this.type.instantiate(snapshot, context, parent);
   }
 
   is(value: IAnyStateTreeNode): value is this["InstanceType"];

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,7 +1,7 @@
 import type { IAnyModelType as MSTAnyModelType, IAnyType as MSTAnyType } from "mobx-state-tree";
 import { isReferenceType, isStateTreeNode as mstIsStateTreeNode, types as mstTypes } from "mobx-state-tree";
 import { types } from ".";
-import { BaseType, setParent } from "./base";
+import { BaseType, setEnv, setParent } from "./base";
 import { ensureRegistered } from "./class-model";
 import { CantRunActionError } from "./errors";
 import { $identifier, $originalDescriptor, $readOnly, $type } from "./symbols";
@@ -247,6 +247,7 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
     }
 
     setParent(instance, parent);
+    setEnv(instance, context.env);
 
     return instance as this["InstanceType"];
   }

--- a/src/model.ts
+++ b/src/model.ts
@@ -106,7 +106,7 @@ export const instantiateInstanceFromProperties = (
 
   if (identifierProp) {
     const id = instance[identifierProp];
-    Object.defineProperty(instance, $identifier, { value: id });
+    instance[$identifier] = id;
     context.referenceCache.set(id, instance);
   }
 };

--- a/src/optional.ts
+++ b/src/optional.ts
@@ -8,6 +8,7 @@ import type {
   InstanceWithoutSTNTypeForType,
   InstantiateContext,
   IOptionalType,
+  IStateTreeNode,
   ValidOptionalValue,
 } from "./types";
 
@@ -30,7 +31,7 @@ export class OptionalType<T extends IAnyType, OptionalValues extends [ValidOptio
     );
   }
 
-  instantiate(snapshot: this["InputType"], context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"], context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
     if (this.undefinedValues) {
       if (this.undefinedValues.includes(snapshot)) {
         snapshot = this.defaultValue;
@@ -39,7 +40,7 @@ export class OptionalType<T extends IAnyType, OptionalValues extends [ValidOptio
       snapshot = this.defaultValue;
     }
 
-    return this.type.instantiate(snapshot, context);
+    return this.type.instantiate(snapshot, context, parent);
   }
 
   is(value: IAnyStateTreeNode): value is this["InstanceType"];

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -3,7 +3,14 @@ import { types } from "mobx-state-tree";
 import type { ReferenceT } from "mobx-state-tree/dist/internal";
 import { BaseType } from "./base";
 import { ensureRegistered } from "./class-model";
-import type { IAnyComplexType, IMaybeType, IReferenceType, InstanceWithoutSTNTypeForType, InstantiateContext } from "./types";
+import type {
+  IAnyComplexType,
+  IMaybeType,
+  IReferenceType,
+  IStateTreeNode,
+  InstanceWithoutSTNTypeForType,
+  InstantiateContext,
+} from "./types";
 
 export type SafeReferenceOptions<T extends IAnyComplexType> = (ReferenceOptionsGetSet<T["mstType"]> | Record<string, unknown>) & {
   acceptsUndefined?: boolean;
@@ -15,7 +22,7 @@ class ReferenceType<TargetType extends IAnyComplexType> extends BaseType<string,
     super(types.reference(targetType.mstType, options));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (!snapshot || !context.referenceCache.has(snapshot)) {
       throw new Error(`can't resolve reference ${snapshot}`);
     }
@@ -37,7 +44,7 @@ class SafeReferenceType<TargetType extends IAnyComplexType> extends BaseType<
     super(types.safeReference(targetType.mstType, options));
   }
 
-  instantiate(snapshot: string | undefined, context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: string | undefined, context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (!snapshot || !context.referenceCache.has(snapshot)) {
       return undefined as this["InstanceType"];
     }

--- a/src/refinement.ts
+++ b/src/refinement.ts
@@ -1,15 +1,15 @@
 import type { Instance } from "mobx-state-tree";
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { IAnyType, InstanceWithoutSTNTypeForType, InstantiateContext, IType } from "./types";
+import type { IAnyType, InstanceWithoutSTNTypeForType, InstantiateContext, IStateTreeNode, IType } from "./types";
 
 class RefinementType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputType"], InstanceWithoutSTNTypeForType<T>> {
   constructor(readonly type: T, readonly predicate: (snapshot: Instance<T> | Instance<T["mstType"]>) => boolean) {
     super(types.refinement(type.mstType, predicate));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext): this["InstanceType"] {
-    const instance = this.type.instantiate(snapshot, context);
+  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
+    const instance = this.type.instantiate(snapshot, context, parent);
     if (!this.predicate(instance)) {
       throw new Error("given snapshot isn't valid for refinement type");
     }

--- a/src/simple.ts
+++ b/src/simple.ts
@@ -1,7 +1,7 @@
 import type { ISimpleType as MSTSimpleType } from "mobx-state-tree";
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { InstantiateContext, ISimpleType } from "./types";
+import type { InstantiateContext, ISimpleType, IStateTreeNode } from "./types";
 
 export type Primitives = string | number | boolean | Date | null | undefined;
 
@@ -14,7 +14,7 @@ export class SimpleType<T> extends BaseType<T, T, T> {
     super(mstType);
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot === undefined) {
       throw new Error(`can't initialize simple type ${this.name} with undefined`);
     }
@@ -28,7 +28,7 @@ export class SimpleType<T> extends BaseType<T, T, T> {
 }
 
 export class DateType extends BaseType<Date | number, number, Date> {
-  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot === undefined) {
       throw new Error(`can't initialize simple type ${this.name} with undefined`);
     }
@@ -47,7 +47,7 @@ export class IntegerType extends BaseType<number, number, number> {
     super(types.integer);
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (!Number.isInteger(snapshot)) {
       throw new Error(`can't initialize integer with ${snapshot}`);
     }
@@ -66,7 +66,7 @@ export class NullType extends BaseType<null, null, null> {
     super(types.null);
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot !== null) {
       throw new Error(`can't initialize null with ${snapshot}`);
     }
@@ -85,7 +85,7 @@ export class LiteralType<T extends Primitives> extends SimpleType<T> {
     super(typeof value, types.literal<T>(value));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot !== this.value) {
       throw new Error(`expected literal type to be initialized with ${this.value}`);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface IType<InputType, OutputType, InstanceType> {
   createReadOnly(snapshot?: InputType, env?: any): this["InstanceType"];
 
   /** @hidden */
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext): this["InstanceType"];
+  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"];
 }
 
 /**
@@ -145,7 +145,7 @@ export interface IClassModelType<
   volatiles: Record<string, VolatileMetadata>;
 
   /** @hidden */
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext): InstanceType<this>;
+  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): InstanceType<this>;
 
   is(value: IAnyStateTreeNode): value is InstanceType<this>;
   is(value: any): value is this["InputType"] | InstanceType<this>;

--- a/src/union.ts
+++ b/src/union.ts
@@ -2,7 +2,7 @@ import type { IType, UnionOptions as MSTUnionOptions } from "mobx-state-tree";
 import { types as mstTypes } from "mobx-state-tree";
 import { BaseType } from "./base";
 import { ensureRegistered, isClassModel } from "./class-model";
-import type { IAnyType, InstanceWithoutSTNTypeForType, InstantiateContext, IUnionType } from "./types";
+import type { IAnyType, InstanceWithoutSTNTypeForType, InstantiateContext, IStateTreeNode, IUnionType } from "./types";
 import { OptionalType } from "./optional";
 import { isModelType, isType } from "./api";
 import { LiteralType } from "./simple";
@@ -44,7 +44,7 @@ const buildDiscriminatorTypeMap = (types: IAnyType[], discriminator: string) => 
     } else if (isClassModel(type) || isModelType(type)) {
       setMapValue(type.properties[discriminator], instantiateAsType);
     } else if (type instanceof OptionalType) {
-      const value = type.instantiate(undefined, emptyContext);
+      const value = type.instantiate(undefined, emptyContext, null);
       map[value] = instantiateAsType;
     } else if (type instanceof LiteralType) {
       map[type.value] = instantiateAsType;
@@ -112,7 +112,7 @@ class UnionType<Types extends IAnyType[]> extends BaseType<
     this.dispatcher = dispatcher;
   }
 
-  instantiate(snapshot: this["InputType"], context: InstantiateContext): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"], context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
     let type: Types[number] | undefined;
     if (this.dispatcher) {
       type = this.dispatcher(snapshot);
@@ -127,7 +127,7 @@ class UnionType<Types extends IAnyType[]> extends BaseType<
       throw new Error("couldn't find valid type from union for given snapshot");
     }
 
-    return type.instantiate(snapshot, context);
+    return type.instantiate(snapshot, context, parent);
   }
 
   is(value: any): value is this["InstanceType"];


### PR DESCRIPTION
This improves the raw speed that MQT can create read-only instances a lot! I did some profiling with a new benchmark that really stresses class model, map, and array creation, and it showed that a huge amount of time was being spent in the `Object.defineProperty` and `Reflect.defineProperty` calls that we make to track our internal state, like the environment, the parent, and the type of each object. For each of those three, I tried to come up with different strategies that didn't require these slow property setters.

The results are good!

On `main`:

```
❯ p x bench/create-large-root.ts

> @gadgetinc/mobx-quick-tree@0.4.0 x /Users/airhorns/Code/mobx-quick-tree
> ts-node --transpile-only "bench/create-large-root.ts"

instantiating a large root x 395 ops/sec ±0.88% (90 runs sampled)
```

On `faster-instantiation`:

```
❯ p x bench/create-large-root.ts

> @gadgetinc/mobx-quick-tree@0.4.0 x /Users/airhorns/Code/mobx-quick-tree
> ts-node --transpile-only "bench/create-large-root.ts"

instantiating a large root x 925 ops/sec ±1.01% (88 runs sampled)
```

Here's the benchmark code: https://github.com/gadget-inc/mobx-quick-tree/blob/main/bench/create-large-root.ts and the shape of the object: https://github.com/gadget-inc/mobx-quick-tree/blob/main/spec/fixtures/LargeRoot.ts#L148

I went commit by commit for each change so it may be easier to review that way as well.