### PR TITLE
Putting the quick in quick tree: compile an instantiation function for each class model type

### DIFF
--- a/src/fast-instantiator.ts
+++ b/src/fast-instantiator.ts
@@ -1,0 +1,160 @@
+import { OptionalType } from "./optional";
+import { isReferenceType } from "./api";
+import { LiteralType } from "./simple";
+import { IntegerType, SimpleType } from "./simple";
+import type { IAnyClassModelType, IAnyType, IClassModelType, Instance, InstantiateContext, SnapshotIn, ValidOptionalValue } from "./types";
+
+export const $fastInstantiator = Symbol.for("mqt:class-model-instantiator");
+
+export type CompiledInstantiator<T extends IAnyClassModelType = IAnyClassModelType> = (
+  instance: Instance<T>,
+  snapshot: SnapshotIn<T>,
+  context: InstantiateContext
+) => void;
+
+/**
+ * Compiles a fast function for taking snapshots and turning them into instances of a class model.
+ **/
+export const buildFastInstantiator = <T extends IClassModelType<Record<string, IAnyType>, any, any>>(model: T): CompiledInstantiator<T> => {
+  return new InstantiatorBuilder(model).build();
+};
+
+type DirectlyAssignableType = SimpleType<any> | IntegerType | LiteralType<any>;
+const isDirectlyAssignableType = (type: IAnyType): type is DirectlyAssignableType =>
+  type instanceof SimpleType || type instanceof IntegerType || type instanceof LiteralType;
+
+class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, any, any>> {
+  aliases = new Map<string, string>();
+
+  constructor(readonly model: T) {}
+
+  build(): CompiledInstantiator<T> {
+    const segments: string[] = [];
+
+    for (const [key, type] of Object.entries(this.model.properties)) {
+      if (isDirectlyAssignableType(type)) {
+        segments.push(`
+        // simple type for ${key}
+        instance["${key}"] = ${this.expressionForDirectlyAssignableType(key, type)};
+      `);
+      } else if (type instanceof OptionalType) {
+        segments.push(this.assignmentExpressionForOptionalType(key, type));
+      } else if (isReferenceType(type.mstType)) {
+        segments.push(`
+        // setup reference for ${key}
+        context.referencesToResolve.push(() => {
+          instance["${key}"] = ${this.alias(`model.properties["${key}"]`)}.instantiate(
+            snapshot?.["${key}"], 
+            context, 
+            instance
+          );
+        });
+      `);
+      } else {
+        segments.push(`
+          // instantiate fallback for ${key}
+          instance["${key}"] = ${this.alias(`model.properties["${key}"]`)}.instantiate(
+            snapshot?.["${key}"], 
+            context, 
+            instance
+          );
+        `);
+      }
+    }
+
+    for (const [key, _metadata] of Object.entries(this.model.volatiles)) {
+      segments.push(`
+      instance["${key}"] = ${this.alias(`model.volatiles["${key}"]`)}.initializer(instance);
+    `);
+    }
+
+    const identifierProp = this.model.mstType.identifierAttribute;
+    if (identifierProp) {
+      segments.push(`
+      const id = instance["${identifierProp}"];
+      instance[Symbol.for("MQT_identifier")] = id;
+      context.referenceCache.set(id, instance); 
+    `);
+    }
+
+    const innerFunc = `
+      return function(instance, snapshot, context) {
+        ${segments.join("\n")}
+      }
+    `;
+
+    // build a function that closes over a bunch of aliased expressions
+    // evaluate the inner function source code in this closure to return the function
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const aliasFunc = new Function(
+      "model",
+      "innerFunc",
+      `
+      ${Array.from(this.aliases.entries())
+        .map(([expression, alias]) => `const ${alias} = ${expression};`)
+        .join("\n")}
+
+      ${innerFunc}
+    `
+    );
+
+    // evaluate aliases and get created inner function
+    const func = aliasFunc(this.model);
+    // console.log(`function for ${this.model.name}`, "\n\n\n", func.toString(), "\n\n\n");
+    return func;
+  }
+
+  expressionForDirectlyAssignableType(key: string, _type: DirectlyAssignableType) {
+    return `snapshot?.["${key}"]`;
+  }
+
+  assignmentExpressionForOptionalType(key: string, type: OptionalType<IAnyType, [ValidOptionalValue, ...ValidOptionalValue[]]>) {
+    let defaultValueExpression;
+    if (type.defaultValueOrFunc instanceof Function) {
+      defaultValueExpression = `model.properties["${key}"].defaultValueOrFunc()`;
+    } else {
+      defaultValueExpression = JSON.stringify(type.defaultValueOrFunc);
+    }
+
+    const varName = `snapshotValue${key}`;
+
+    const comparisonsToUndefinedValues = (type.undefinedValues ?? [undefined]).map((value) => {
+      return `(${varName} === ${JSON.stringify(value)})`;
+    });
+
+    let createExpression;
+    if (isDirectlyAssignableType(type.type)) {
+      createExpression = `
+      instance["${key}"] = ${varName}
+      `;
+    } else {
+      createExpression = `
+      instance["${key}"] = ${this.alias(`model.properties["${key}"].type`)}.instantiate(
+        ${varName}, 
+        context, 
+        instance
+      );
+      `;
+    }
+
+    return `
+      // optional type for ${key}
+      let ${varName} = snapshot?.["${key}"];
+      if (${comparisonsToUndefinedValues.join(" || ")}) {
+        ${varName} = ${defaultValueExpression}
+      }
+      ${createExpression}
+    `;
+  }
+
+  alias(expression: string): string {
+    const existing = this.aliases.get(expression);
+    if (existing) {
+      return existing;
+    }
+
+    const alias = `v${this.aliases.size}`;
+    this.aliases.set(expression, alias);
+    return alias;
+  }
+}

--- a/src/map.ts
+++ b/src/map.ts
@@ -72,7 +72,7 @@ export class QuickMap<T extends IAnyType> extends Map<string, Instance<T>> imple
   }
 }
 
-class MapType<T extends IAnyType> extends BaseType<
+export class MapType<T extends IAnyType> extends BaseType<
   Record<string, T["InputType"]> | undefined,
   Record<string, T["OutputType"]>,
   IMSTMap<T>

--- a/src/optional.ts
+++ b/src/optional.ts
@@ -14,15 +14,14 @@ import type {
 
 export type DefaultFuncOrValue<T extends IAnyType> = T["InputType"] | T["OutputType"] | (() => CreateTypes<T>);
 
-export class OptionalType<T extends IAnyType, OptionalValues extends [ValidOptionalValue, ...ValidOptionalValue[]]> extends BaseType<
-  T["InputType"] | OptionalValues[number],
-  T["OutputType"],
-  InstanceWithoutSTNTypeForType<T>
-> {
+export class OptionalType<
+  T extends IAnyType,
+  OptionalValues extends [ValidOptionalValue, ...ValidOptionalValue[]] = [undefined]
+> extends BaseType<T["InputType"] | OptionalValues[number], T["OutputType"], InstanceWithoutSTNTypeForType<T>> {
   constructor(
     readonly type: T,
-    private readonly defaultValueOrFunc: DefaultFuncOrValue<T>,
-    private readonly undefinedValues?: OptionalValues
+    readonly defaultValueOrFunc: DefaultFuncOrValue<T>,
+    readonly undefinedValues: OptionalValues = [undefined] as any
   ) {
     super(
       undefinedValues

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -17,7 +17,7 @@ export type SafeReferenceOptions<T extends IAnyComplexType> = (ReferenceOptionsG
   onInvalidated?: OnReferenceInvalidated<ReferenceT<T["mstType"]>>;
 };
 
-class ReferenceType<TargetType extends IAnyComplexType> extends BaseType<string, string, InstanceWithoutSTNTypeForType<TargetType>> {
+export class ReferenceType<TargetType extends IAnyComplexType> extends BaseType<string, string, InstanceWithoutSTNTypeForType<TargetType>> {
   constructor(readonly targetType: IAnyComplexType, options?: ReferenceOptions<TargetType["mstType"]>) {
     super(types.reference(targetType.mstType, options));
   }
@@ -35,7 +35,7 @@ class ReferenceType<TargetType extends IAnyComplexType> extends BaseType<string,
   }
 }
 
-class SafeReferenceType<TargetType extends IAnyComplexType> extends BaseType<
+export class SafeReferenceType<TargetType extends IAnyComplexType> extends BaseType<
   string | undefined,
   string | undefined,
   InstanceWithoutSTNTypeForType<TargetType> | undefined

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import type { IInterceptor, IMapDidChange, IMapWillChange, Lambda } from "mobx";
 import type { IAnyType as MSTAnyType } from "mobx-state-tree";
 import type { VolatileMetadata } from "./class-model";
 import type { $quickType, $registered, $type } from "./symbols";
+import { $fastInstantiator, CompiledInstantiator } from "./fast-instantiator";
 
 export type { $quickType, $registered, $type } from "./symbols";
 export type { IJsonPatch, IMiddlewareEvent, IPatchRecorder, ReferenceOptions, UnionOptions } from "mobx-state-tree";
@@ -125,6 +126,7 @@ export interface IClassModelType<
 > {
   readonly [$quickType]: undefined;
   readonly [$registered]: true;
+  [$fastInstantiator]: CompiledInstantiator;
 
   readonly InputType: InputType;
   readonly OutputType: OutputType;


### PR DESCRIPTION
I was curious about how hard and how effective the "compile a function that does the same thing but with loops unrolled and indirection removed" approach would be for model instantiation. I tried it. It works ... really well.

On `main`:

```
❯ p x bench/create-large-root.ts

> @gadgetinc/mobx-quick-tree@0.4.0 x /Users/airhorns/Code/mobx-quick-tree
> ts-node --transpile-only "bench/create-large-root.ts"

instantiating a large root x 395 ops/sec ±0.88% (90 runs sampled)
```

On the first pass optimization branch in #44:

```
❯ p x bench/create-large-root.ts

> @gadgetinc/mobx-quick-tree@0.4.0 x /Users/airhorns/Code/mobx-quick-tree
> ts-node --transpile-only "bench/create-large-root.ts"

instantiating a large root x 925 ops/sec ±1.01% (88 runs sampled)
```

On this branch:

```
❯ p x bench/create-large-root.ts

> @gadgetinc/mobx-quick-tree@0.4.0 x /Users/airhorns/Code/mobx-quick-tree
> ts-node --transpile-only "bench/create-large-root.ts"

instantiating a large root x 3,182 ops/sec ±0.26% (97 runs sampled)
```

I am surprised and delighted 💨 💨 💨 . I can also confirm this is real, I pushed a prerelease to Gadget to see if I was smoking performance-enhancing drugs and https://github.com/gadget-inc/gadget/pull/6444 is green!

The old approach that instantiated every class model looked like this: 

```typescript
export const instantiateInstanceFromProperties = (
  instance: any,
  snapshot: Record<string, any> | undefined,
  properties: ModelProperties,
  identifierProp: string | undefined,
  context: InstantiateContext
) => {
  for (const propName in properties) {
    const propType = properties[propName];
    if (isReferenceType(propType.mstType)) {
      context.referencesToResolve.push(() => {
        const propValue = propType.instantiate(snapshot?.[propName], context);
        instance[propName] = propValue;
      });
      continue;
    }

    const propValue = propType.instantiate(snapshot?.[propName], context);
    setParent(propValue, instance);
    instance[propName] = propValue;
  }

  if (identifierProp) {
    const id = instance[identifierProp];
    Object.defineProperty(instance, $identifier, { value: id });
    context.referenceCache.set(id, instance);
  }
};
```

which is to say, loop over the `SomeClassModel.properties` object which stores `{ key: SimpleType, createdDate: DateType, childObjects: MapType}` etc, grabbing each key/value of the snapshot and using the type from the `.properties` to go from snapshot => live MQT object. This snapshot => live MQT object transform is what the `.instantiate` function on all our types is responsible for. Some examples:
 - on strings and numbers, do nothing
 - on dates, convert the incoming snapshot epoch number to a date with `new Date()`
 - on optional types, check for undefined / null and use the default if the snapshot is that, otherwise, instantiate the actual type 
 - on map types, create an instance for each of the snapshot values, then assemble them into a `QuickMap` map 

So, our compiler emits inline JS to do each of those things for the types we've fast-pathed, and then falls back on the existing `.instantiate` implementations for anything we haven't.

Here's what a compiled instantiation function looks like:

```javascript
function buildCustomerInstantiator(model, imports) {
  const { QuickMap, $identifier } = imports;
  const v0 = model.properties["email"];
  const v1 = model.properties["phoneNumber"];

  return function InstantiateCustomer(instance, snapshot, context) {
    // optional type for type
    let snapshotValuetype = snapshot?.["type"];
    if (snapshotValuetype === undefined) {
      snapshotValuetype = "Customer";
    }

    instance["type"] = snapshotValuetype;

    // simple type for key
    instance["key"] = snapshot?.["key"];

    // simple type for firstName
    instance["firstName"] = snapshot?.["firstName"];

    // simple type for lastName
    instance["lastName"] = snapshot?.["lastName"];

    // instantiate fallback for email of type (string | null)
    instance["email"] = v0.instantiate(snapshot?.["email"], context, instance);

    // instantiate fallback for phoneNumber of type (string | null)
    instance["phoneNumber"] = v1.instantiate(
      snapshot?.["phoneNumber"],
      context,
      instance
    );

    // optional type for createdAt
    let snapshotValuecreatedAt = snapshot?.["createdAt"];
    if (snapshotValuecreatedAt === undefined) {
      snapshotValuecreatedAt =
        model.properties["createdAt"].defaultValueOrFunc();
    }

    instance["createdAt"] = snapshotValuecreatedAt;

    const id = instance["key"];
    instance[$identifier] = id;
    context.referenceCache.set(id, instance);
  };
}
```

The weird outer function is an artifact of the way that you are supposed to do `eval` in JS these days. `eval` is the sketchiest and slowest of the options -- better is to use `new Function(<source>)`, which creates a new function in the global scope instead of the local one. This is good because you can't accidentally close over a bunch of stuff and leak it, but bad because if you do need context in the created function, you have to inject it weirdly. So, we actually create two functions: an outer one which establishes any variables we need in scope, like types or the `QuickMap` constructor, and then an inner function which is the one we actually run over and over and is the thing that needs to be very fast. Not super important but does make things look a bit weird.

There's a couple downsides of this whole approach:
 - the fast-path implementations could diverge from the slow-path, leading to hard to diagnose bugs
 - different type arrangements might expose end-user types to different paths over time
 - the fast-paths do a bit less less data validation, and may allow incorrect snapshots silently. We actually already accepted this for MQT, and rely on MST to do typechecking at write time, so MQT already doesn't do much runtime type validation at all, but the fast paths do even less.
 
Personally, I've found that the instantiate implementations haven't changed that much -- we've changed how we structure it all, but we haven't changed the core ideas at all. MQT since inception has had the same idea of an optional type, a map, of an array, of a model, etc, and I don't expect much churn in the list of primitives. I think we can expect some churn in how we implement them to be incredibly fast, but because the requirements are relatively set, I am ok adding brittleness to get that speed. 