### PR TITLE
Fast instantiation through lazy types

### DIFF
--- a/spec/fixtures/FruitAisle.ts
+++ b/spec/fixtures/FruitAisle.ts
@@ -58,7 +58,7 @@ export const Fruit = types.union({ discriminator: "type" }, Apple, Banana, Banan
 @register
 export class FruitBin extends ClassModel({
   type: nodeTypeType("FruitBin"),
-  fruit: Fruit,
+  fruit: types.late(() => Fruit),
   count: types.integer,
 }) {}
 

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -302,7 +302,14 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
     (klass as any).mstType = (klass as any).mstType.volatile((self: any) => initializeVolatiles({}, self, mstVolatiles));
   }
 
-  klass[$fastInstantiator] = buildFastInstantiator(klass);
+  // define the fast instantiation function on this class
+  // we only actually build the function the first time the class is instantiated in order to support evaluating types.late as late as possible
+  klass[$fastInstantiator] = (instance, snapshot, context) => {
+    const intantiator = buildFastInstantiator(klass);
+    klass[$fastInstantiator] = intantiator;
+    return intantiator(instance, snapshot, context);
+  };
+
   (klass as any)[$registered] = true;
 
   return klass as any;

--- a/src/late.ts
+++ b/src/late.ts
@@ -3,7 +3,7 @@ import { BaseType } from "./base";
 import { ensureRegistered } from "./class-model";
 import type { IAnyType, IStateTreeNode, InstanceWithoutSTNTypeForType, InstantiateContext } from "./types";
 
-class LateType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputType"], InstanceWithoutSTNTypeForType<T>> {
+export class LateType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputType"], InstanceWithoutSTNTypeForType<T>> {
   private cachedType: T | null | undefined;
 
   constructor(private readonly fn: () => T) {
@@ -18,7 +18,7 @@ class LateType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputTyp
     return this.type.is(value);
   }
 
-  private get type() {
+  get type() {
     this.cachedType ??= this.fn();
     ensureRegistered(this.cachedType);
     return this.cachedType;


### PR DESCRIPTION
Before, we reverted to the slow path instantiation for all late types which is a bit of a fail -- if it was a plain old optional type or similar within the late, we'd skip the fast path completely. Instead, if we build the instantiator late, we can shuck the late wrapper around the actual type, and use fast path instantiation for the type if available.

On main with a lazy type on the fruit aisle:

```
❯ p x bench/all.ts

> @gadgetinc/mobx-quick-tree@0.4.0 x /Users/airhorns/Code/mobx-quick-tree
> ts-node --transpile-only "bench/all.ts"

instantiating a small root x 906,528 ops/sec ±0.59% (88 runs sampled)
instantiating a large root x 2,860 ops/sec ±3.27% (89 runs sampled)
instantiating a large union x 168,566 ops/sec ±1.40% (91 runs sampled)
```

On this branch:

```
> @gadgetinc/mobx-quick-tree@0.4.0 x /Users/airhorns/Code/mobx-quick-tree
> ts-node --transpile-only "bench/all.ts"

instantiating a small root x 972,796 ops/sec ±0.38% (89 runs sampled)
instantiating a large root x 2,979 ops/sec ±3.12% (95 runs sampled)
instantiating a large union x 217,545 ops/sec ±1.32% (97 runs sampled)
```