### PR TITLE
Export unescapeJsonPath from mobx-state-tree

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -68,9 +68,10 @@ export {
   splitJsonPath,
   tryReference,
   typecheck,
+  unescapeJsonPath,
   walk,
 } from "mobx-state-tree";
-export { ClassModel, action, volatileAction, register, view, extend } from "./class-model";
+export { ClassModel, action, extend, register, view, volatileAction } from "./class-model";
 export { getSnapshot } from "./snapshot";
 
 export const isType = (value: any): value is IAnyType => {


### PR DESCRIPTION
Needed this for some work I'm doing and saw it wasn't there, so let's export it 🚀 

For the time being, I'm going to implement it myself, since it's a pretty simple transform, but thought it would be good to include it for moving forward.