### PR TITLE
Faster constructor 

### DIFF
--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -37,3 +37,15 @@ export const $registered = Symbol.for("MQT_registered");
  * @hidden
  **/
 export const $volatileDefiner = Symbol.for("MQT_volatileDefiner");
+
+/**
+ * The values of memoized properties on an MQT instance
+ * @hidden
+ **/
+export const $memos = Symbol.for("mqt:class-model-memos");
+
+/**
+ * The list of properties which have been memoized
+ * @hidden
+ **/
+export const $memoizedKeys = Symbol.for("mqt:class-model-memoized-keys");

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,6 @@ import type { IInterceptor, IMapDidChange, IMapWillChange, Lambda } from "mobx";
 import type { IAnyType as MSTAnyType } from "mobx-state-tree";
 import type { VolatileMetadata } from "./class-model";
 import type { $quickType, $registered, $type } from "./symbols";
-import { $fastInstantiator, CompiledInstantiator } from "./fast-instantiator";
 
 export type { $quickType, $registered, $type } from "./symbols";
 export type { IJsonPatch, IMiddlewareEvent, IPatchRecorder, ReferenceOptions, UnionOptions } from "mobx-state-tree";
@@ -129,7 +128,6 @@ export interface IClassModelType<
 > {
   readonly [$quickType]: undefined;
   readonly [$registered]: true;
-  [$fastInstantiator]: CompiledInstantiator;
 
   readonly InputType: InputType;
   readonly OutputType: OutputType;


### PR DESCRIPTION
On top of https://github.com/gadget-inc/mobx-quick-tree/pull/65

15% improvement by removing a megamorphic call to the fast instantiator function! Yeesh!

On `perf-improvements`:

```
❯ node dist/bench/create-many-different-roots.js
instantiating a large root x 3,258 ops/sec ±0.84% (100 runs sampled)
instantiating a small root x 10,573,575 ops/sec ±0.21% (92 runs sampled)
instantiating a diverse root x 464,002 ops/sec ±0.15% (100 runs sampled)
```

On this branch:

```
❯ node dist/bench/create-many-different-roots.js
instantiating a large root x 3,851 ops/sec ±0.29% (97 runs sampled)
instantiating a small root x 15,595,988 ops/sec ±0.46% (99 runs sampled)
instantiating a diverse root x 582,571 ops/sec ±0.65% (99 runs sampled)
```