### PR TITLE
Add nix and upgrade node

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+use flake
+
+source_env_if_exists .envrc.local

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -8,13 +8,13 @@ runs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 21
 
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 7
+          version: 8
           run_install: false
 
       - name: Get pnpm store directory

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+.direnv
 dist
 node_modules
 yarn.lock
 vscode-profile*
 isolate-*
 flamegraph.html
+*.perf

--- a/Benchmarking.md
+++ b/Benchmarking.md
@@ -35,7 +35,7 @@ node --prof-process isolate-*.log
 You can postprocess the generated `isolate-0x<something>.log` file into the data `flamegraph` expects, and then feed it to `flamegraph` to see a visual breakdown of performance. You can do that in one command like so:
 
 ```shell
-node --prof-process --preprocess -j isolate-*.log | p flamebearer
+node --prof-process --preprocess -j isolate-*.log | pnpm flamebearer
 ```
 
 #### CPU profiling with VSCode

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1699343069,
+        "narHash": "sha256-s7BBhyLA6MI6FuJgs4F/SgpntHBzz40/qV0xLPW6A1Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ec750fd01963ab6b20ee1f0cb488754e8036d89d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "mobx-quick-tree development environment";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }:
+    (flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ]
+      (system: nixpkgs.lib.fix (flake:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        rec {
+
+          packages =
+            rec {
+              bash = pkgs.bash;
+              nodejs = pkgs.nodejs_21;
+              pnpm = pkgs.nodejs_21.pkgs.pnpm;
+            };
+
+          devShell = pkgs.mkShell {
+            packages = builtins.attrValues packages;
+          };
+        }
+      )));
+}

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -37,3 +37,15 @@ export const $registered = Symbol.for("MQT_registered");
  * @hidden
  **/
 export const $volatileDefiner = Symbol.for("MQT_volatileDefiner");
+
+/**
+ * The values of memoized properties on an MQT instance
+ * @hidden
+ **/
+export const $memos = Symbol.for("mqt:class-model-memos");
+
+/**
+ * The list of properties which have been memoized
+ * @hidden
+ **/
+export const $memoizedKeys = Symbol.for("mqt:class-model-memoized-keys");

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,6 @@ import type { IInterceptor, IMapDidChange, IMapWillChange, Lambda } from "mobx";
 import type { IAnyType as MSTAnyType } from "mobx-state-tree";
 import type { VolatileMetadata } from "./class-model";
 import type { $quickType, $registered, $type } from "./symbols";
-import { $fastInstantiator, CompiledInstantiator } from "./fast-instantiator";
 
 export type { $quickType, $registered, $type } from "./symbols";
 export type { IJsonPatch, IMiddlewareEvent, IPatchRecorder, ReferenceOptions, UnionOptions } from "mobx-state-tree";
@@ -129,7 +128,6 @@ export interface IClassModelType<
 > {
   readonly [$quickType]: undefined;
   readonly [$registered]: true;
-  [$fastInstantiator]: CompiledInstantiator;
 
   readonly InputType: InputType;
   readonly OutputType: OutputType;


### PR DESCRIPTION
So we're all using the same version when comparing benchmarks. Regrettably, there's a huge performance regression on newer nodes! I am going to work on that next, but at least with a nix setup we're comparing apples to apples.

```
❯ node --version
v21.1.0
❯ p x bench/create-many-different-roots.ts

> @gadgetinc/mobx-quick-tree@0.4.4 x /Users/airhorns/Code/mobx-quick-tree
> ts-node --transpile-only "bench/create-many-different-roots.ts"

instantiating a large root x 3,047 ops/sec ±1.32% (99 runs sampled)
instantiating a small root x 11,136,120 ops/sec ±0.47% (100 runs sampled)
instantiating a diverse root x 449,239 ops/sec ±0.16% (98 runs sampled)
```

```
❯ node --version
v20.9.0
❯ p x bench/create-many-different-roots.ts

> @gadgetinc/mobx-quick-tree@0.4.4 x /Users/airhorns/Code/mobx-quick-tree
> ts-node --transpile-only "bench/create-many-different-roots.ts"

instantiating a large root x 3,243 ops/sec ±0.56% (98 runs sampled)
instantiating a small root x 11,026,548 ops/sec ±0.14% (98 runs sampled)
instantiating a diverse root x 461,517 ops/sec ±0.15% (100 runs sampled)
```

```
❯ node --version
v18.18.2
❯ p x bench/create-many-different-roots.ts
> @gadgetinc/mobx-quick-tree@0.4.4 x /Users/airhorns/Code/mobx-quick-tree
> ts-node --transpile-only "bench/create-many-different-roots.ts"

instantiating a large root x 4,876 ops/sec ±0.56% (98 runs sampled)
instantiating a small root x 9,065,427 ops/sec ±0.89% (93 runs sampled)
instantiating a diverse root x 638,657 ops/sec ±1.81% (97 runs sampled)
```