### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/mobx-quick-tree",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "A mirror of mobx-state-tree's API to construct fast, read-only instances that share all the same views",
   "source": "src/index.ts",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Releasing the performance improvements from 

Decided to go to 0.5.x because technically some properties were previously non-enumerable and now they are (via special means, but still enumerable, and maybe a breaking change).