### PR TITLE
`@snapshottedView`

### DIFF
--- a/spec/__snapshots__/class-model-snapshotted-views.spec.ts.snap
+++ b/spec/__snapshots__/class-model-snapshotted-views.spec.ts.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`class model snapshotted views references references to models with snapshotted views can be instantiated 1`] = `
+{
+  "examples": {
+    "1": {
+      "key": "1",
+      "name": "Alice",
+      "slug": "alice",
+    },
+    "2": {
+      "key": "2",
+      "name": "Bob",
+      "slug": "bob",
+    },
+  },
+  "referrers": {
+    "a": {
+      "example": "1",
+      "id": "a",
+    },
+    "b": {
+      "example": "2",
+      "id": "b",
+    },
+  },
+}
+`;

--- a/spec/class-model-mixins.spec.ts
+++ b/spec/class-model-mixins.spec.ts
@@ -1,7 +1,7 @@
 import type { IsExact } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
 import type { Constructor } from "../src";
-import { isType } from "../src";
+import { isType, snapshottedView } from "../src";
 import { IAnyClassModelType, IAnyStateTreeNode, extend } from "../src";
 import { getSnapshot } from "../src";
 import { ClassModel, action, register, types } from "../src";
@@ -69,6 +69,17 @@ const AddViewMixin = <T extends Constructor<{ name: string }>>(Klass: T) => {
   return MixedIn;
 };
 
+const AddSnapshottedViewMixin = <T extends Constructor<{ name: string }>>(Klass: T) => {
+  class MixedIn extends Klass {
+    @snapshottedView()
+    get snapshottedMixinGetter() {
+      return this.name.toUpperCase();
+    }
+  }
+
+  return MixedIn;
+};
+
 const AddActionMixin = <T extends Constructor<{ name: string }>>(Klass: T) => {
   class MixedIn extends Klass {
     @action
@@ -97,21 +108,25 @@ const AddVolatileMixin = <T extends Constructor<{ name: string }>>(Klass: T) => 
 @register
 class ChainedA extends AddVolatileMixin(
   AddViewMixin(
-    AddActionMixin(
-      ClassModel({
-        name: types.string,
-      }),
+    AddSnapshottedViewMixin(
+      AddActionMixin(
+        ClassModel({
+          name: types.string,
+        }),
+      ),
     ),
   ),
 ) {}
 
 @register
 class ChainedB extends AddActionMixin(
-  AddViewMixin(
-    AddVolatileMixin(
-      ClassModel({
-        name: types.string,
-      }),
+  AddSnapshottedViewMixin(
+    AddViewMixin(
+      AddVolatileMixin(
+        ClassModel({
+          name: types.string,
+        }),
+      ),
     ),
   ),
 ) {}
@@ -120,9 +135,24 @@ class ChainedB extends AddActionMixin(
 class ChainedC extends AddActionMixin(
   AddVolatileMixin(
     AddViewMixin(
-      ClassModel({
-        name: types.string,
-      }),
+      AddSnapshottedViewMixin(
+        ClassModel({
+          name: types.string,
+        }),
+      ),
+    ),
+  ),
+) {}
+
+@register
+class ChainedD extends AddSnapshottedViewMixin(
+  AddActionMixin(
+    AddVolatileMixin(
+      AddViewMixin(
+        ClassModel({
+          name: types.string,
+        }),
+      ),
     ),
   ),
 ) {}
@@ -132,6 +162,7 @@ describe("class model mixins", () => {
     ["Chain A", ChainedA],
     ["Chain B", ChainedB],
     ["Chain C", ChainedC],
+    ["Chain D", ChainedD],
   ])("%s", (_name, Klass) => {
     test("function views can be added to classes by mixins", () => {
       let instance = Klass.createReadOnly({ name: "Test" });
@@ -147,6 +178,17 @@ describe("class model mixins", () => {
 
       instance = Klass.create({ name: "Test" });
       expect(instance.mixinGetter).toBe("TEST");
+    });
+
+    test("snapshotted views can be added to classes by mixins", () => {
+      let instance = Klass.createReadOnly({ name: "Test" });
+      expect(instance.snapshottedMixinGetter).toBe("TEST");
+
+      const snapshot = getSnapshot(instance);
+      expect((snapshot as any).snapshottedMixinGetter).toBe("TEST");
+
+      instance = Klass.createReadOnly({ name: "Test", snapshottedMixinGetter: "foobar" } as any);
+      expect(instance.snapshottedMixinGetter).toBe("foobar");
     });
 
     test("actions can be added to classes by mixins", () => {

--- a/spec/class-model-snapshotted-views.spec.ts
+++ b/spec/class-model-snapshotted-views.spec.ts
@@ -1,0 +1,280 @@
+import { ClassModel, action, snapshottedView, getSnapshot, register, types } from "../src";
+import { Apple } from "./fixtures/FruitAisle";
+import { create } from "./helpers";
+
+@register
+class ViewExample extends ClassModel({ key: types.identifier, name: types.string }) {
+  @snapshottedView()
+  get slug() {
+    return this.name.toLowerCase().replace(/ /g, "-");
+  }
+
+  @action
+  setName(name: string) {
+    this.name = name;
+  }
+}
+
+@register
+class Outer extends ClassModel({ name: types.string, examples: types.array(ViewExample) }) {
+  @snapshottedView()
+  get upperName() {
+    return this.name.toUpperCase();
+  }
+}
+
+describe("class model snapshotted views", () => {
+  describe.each([
+    ["read-only", true],
+    ["observable", false],
+  ])("%s", (_name, readOnly) => {
+    test("instances don't require the snapshot to include the cache", () => {
+      const instance = create(ViewExample, { key: "1", name: "Test" }, readOnly);
+      expect(instance.slug).toEqual("test");
+    });
+
+    test("unchanged instances return the view value in a snapshot of itself when the view is given in the input snapshot", () => {
+      const instance = create(ViewExample, { key: "1", name: "Test", slug: "test" } as any, readOnly);
+      const snapshot = getSnapshot(instance);
+      expect((snapshot as any).slug).toEqual("test");
+    });
+
+    test("unchanged instances return the view value in a snapshot of itself when the view is not given in the input snapshot", () => {
+      const instance = create(ViewExample, { key: "1", name: "Test" } as any, readOnly);
+      const snapshot = getSnapshot(instance);
+      expect((snapshot as any).slug).toEqual("test");
+    });
+
+    test("snapshots of nested instances returns the view value in the snapshot of itself when not given in the input snapshot", () => {
+      const instance = create(Outer, { name: "Test", examples: [{ key: "1", name: "Test" }] } as any, readOnly);
+
+      const snapshot = getSnapshot(instance);
+      expect((snapshot as any).upperName).toEqual("TEST");
+      expect((snapshot as any).examples[0].slug).toEqual("test");
+    });
+
+    test("models with cached views still correctly report .is on totally different models", () => {
+      const instance = create(ViewExample, { key: "1", name: "Test" }, readOnly);
+      expect(ViewExample.is(instance)).toBe(true);
+      expect(Apple.is(instance)).toBe(false);
+
+      const other = create(Apple, { type: "Apple", ripeness: 1 }, readOnly);
+      expect(ViewExample.is(other)).toBe(false);
+      expect(Apple.is(other)).toBe(true);
+    });
+
+    test("instances of models with all optional properties arent .is of other models with all optional properties", () => {
+      @register
+      class AllOptionalA extends ClassModel({ name: types.optional(types.string, "Jim") }) {}
+
+      @register
+      class AllOptionalB extends ClassModel({ title: types.optional(types.string, "Jest") }) {}
+
+      // the empty snapshot matches both types
+      expect(AllOptionalA.is({})).toBe(true);
+      expect(AllOptionalB.is({})).toBe(true);
+
+      const instanceA = create(AllOptionalA, {}, readOnly);
+      expect(AllOptionalA.is(instanceA)).toBe(true);
+      expect(AllOptionalB.is(instanceA)).toBe(false);
+
+      const instanceB = create(AllOptionalA, {}, readOnly);
+      expect(AllOptionalA.is(instanceB)).toBe(true);
+      expect(AllOptionalB.is(instanceB)).toBe(false);
+    });
+
+    // blocked on https://github.com/mobxjs/mobx-state-tree/pull/2182
+    // test("instances of models with all optional properties arent .is of other models with all optional properties with snapshotted views", () => {
+    //   @register
+    //   class AllOptionalA extends ClassModel({ name: types.optional(types.string, "Jim") }) {
+    //     @snapshottedView()
+    //     get slug() {
+    //       return this.name.toLowerCase();
+    //     }
+    //   }
+
+    //   @register
+    //   class AllOptionalB extends ClassModel({ title: types.optional(types.string, "Jest") }) {
+    //     @snapshottedView()
+    //     get whatever() {
+    //       return Math.random();
+    //     }
+    //   }
+
+    //   // the empty snapshot matches both types
+    //   expect(AllOptionalA.is({})).toBe(true);
+    //   expect(AllOptionalB.is({})).toBe(true);
+
+    //   const instanceA = create(AllOptionalA, {}, readOnly);
+    //   expect(AllOptionalA.is(instanceA)).toBe(true);
+    //   expect(AllOptionalB.is(instanceA)).toBe(false);
+
+    //   const instanceB = create(AllOptionalA, {}, readOnly);
+    //   expect(AllOptionalA.is(instanceB)).toBe(true);
+    //   expect(AllOptionalB.is(instanceB)).toBe(false);
+    // });
+  });
+  test("an observable instance saves the view value in a snapshot when changed", () => {
+    const instance = ViewExample.create({ key: "1", name: "Test" });
+    expect(instance.slug).toEqual("test");
+    let snapshot = getSnapshot(instance);
+    expect(snapshot).toEqual({ key: "1", name: "Test", slug: "test" });
+    instance.setName("New Name");
+    snapshot = getSnapshot(instance);
+    expect(snapshot).toEqual({ key: "1", name: "New Name", slug: "new-name" });
+  });
+
+  test("an observable instance updates the saved view when the observed view value changes", () => {
+    const instance = ViewExample.create({ key: "1", name: "Test" });
+    instance.setName("New Name");
+    expect(instance.slug).toEqual("new-name");
+    const snapshot = getSnapshot(instance);
+    expect(snapshot).toEqual({ key: "1", name: "New Name", slug: "new-name" });
+  });
+
+  test("an observable instance ignores the input snapshot value as the logic may have changed", () => {
+    const instance = ViewExample.create({ key: "1", name: "Test", slug: "outdated-cache" } as any);
+    expect(instance.slug).toEqual("test");
+  });
+
+  test("a readonly instance returns the view value from the snapshot if present", () => {
+    const instance = ViewExample.createReadOnly({ key: "1", name: "Test", slug: "test" } as any);
+    expect(instance.slug).toEqual("test");
+  });
+
+  test("a readonly instance doesn't recompute the view value from the snapshot", () => {
+    const instance = ViewExample.createReadOnly({ key: "1", name: "Test", slug: "whatever" } as any);
+    expect(instance.slug).toEqual("whatever");
+  });
+
+  test("a readonly instance doesn't call the computed function if given a snapshot value", () => {
+    const fn = jest.fn();
+    @register
+    class Spy extends ClassModel({ name: types.string }) {
+      @snapshottedView()
+      get slug() {
+        fn();
+        return this.name.toLowerCase().replace(/ /g, "-");
+      }
+    }
+
+    const instance = Spy.createReadOnly({ name: "Test", slug: "whatever" } as any);
+    expect(instance.slug).toEqual("whatever");
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test("an observable instance call the computed function on construction if not given a value", () => {
+    const fn = jest.fn();
+    @register
+    class Spy extends ClassModel({ name: types.string }) {
+      @snapshottedView()
+      get slug() {
+        fn();
+        return this.name.toLowerCase().replace(/ /g, "-");
+      }
+      @action
+      setName(name: string) {
+        this.name = name;
+      }
+    }
+
+    const instance = Spy.create({ name: "Test" });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // not called again upon snapshotting
+    getSnapshot(instance);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    instance.setName("New Name");
+    expect(fn).toHaveBeenCalled();
+  });
+
+  test("snapshotted views can be passed nested within snapshots", () => {
+    const instance = Outer.createReadOnly({
+      name: "foo",
+      upperName: "SNAPSHOT",
+      examples: [{ key: "1", name: "Test", slug: "test-foobar" } as any, { key: "2", name: "Test 2", slug: "test-qux" } as any],
+    } as any);
+
+    expect(instance.upperName).toEqual("SNAPSHOT");
+    expect(instance.examples[0].slug).toEqual("test-foobar");
+    expect(instance.examples[1].slug).toEqual("test-qux");
+  });
+
+  describe("with a hydrator", () => {
+    @register
+    class HydrateExample extends ClassModel({ url: types.string }) {
+      @snapshottedView<URL>({
+        getSnapshot(value, snapshot, node) {
+          expect(snapshot).toBeDefined();
+          expect(node).toBeDefined();
+          return value.toString();
+        },
+        createReadOnly(value, snapshot, node) {
+          expect(snapshot).toBeDefined();
+          expect(node).toBeDefined();
+          return value ? new URL(value) : undefined;
+        },
+      })
+      get withoutParams() {
+        const url = new URL(this.url);
+        for (const [key] of url.searchParams.entries()) {
+          url.searchParams.delete(key);
+        }
+        return url;
+      }
+
+      @action
+      setURL(url: string) {
+        this.url = url;
+      }
+    }
+
+    test("snapshotted views with processors can be accessed on observable instances", () => {
+      const instance = HydrateExample.create({ url: "https://gadget.dev/blog/feature?utm=whatever" });
+      expect(instance.withoutParams).toEqual(new URL("https://gadget.dev/blog/feature"));
+    });
+
+    test("snapshotted views with processors can be accessed on readonly instances when there's no input data", () => {
+      const instance = HydrateExample.create({ url: "https://gadget.dev/blog/feature?utm=whatever" });
+      expect(instance.withoutParams).toEqual(new URL("https://gadget.dev/blog/feature"));
+    });
+
+    test("snapshotted views with processors can be accessed on readonly instances when there is input data", () => {
+      const instance = HydrateExample.createReadOnly({
+        url: "https://gadget.dev/blog/feature?utm=whatever",
+        withoutParams: "https://gadget.dev/blog/feature/extra", // pass a different value so we can be sure it is what is being used
+      } as any);
+      expect(instance.withoutParams).toEqual(new URL("https://gadget.dev/blog/feature/extra"));
+    });
+  });
+
+  describe("references", () => {
+    @register
+    class Referencer extends ClassModel({
+      id: types.identifier,
+      example: types.reference(ViewExample),
+    }) {}
+
+    @register
+    class Root extends ClassModel({
+      referrers: types.map(Referencer),
+      examples: types.map(ViewExample),
+    }) {}
+
+    test("references to models with snapshotted views can be instantiated", () => {
+      const root = Root.createReadOnly({
+        referrers: {
+          a: { id: "a", example: "1" },
+          b: { id: "b", example: "2" },
+        },
+        examples: {
+          "1": { key: "1", name: "Alice" },
+          "2": { key: "2", name: "Bob" },
+        },
+      });
+
+      expect(getSnapshot(root)).toMatchSnapshot();
+    });
+  });
+});

--- a/spec/class-model-snapshotted-views.spec.ts
+++ b/spec/class-model-snapshotted-views.spec.ts
@@ -24,10 +24,13 @@ class Outer extends ClassModel({ name: types.string, examples: types.array(ViewE
 }
 
 describe("class model snapshotted views", () => {
-  describe.each([
-    ["read-only", true],
-    ["observable", false],
-  ])("%s", (_name, readOnly) => {
+  // describe.each([
+  //   ["read-only", true],
+  //   ["observable", false],
+  // ])("%s", (_name, readOnly) => {
+  describe("whatever", () => {
+    const readOnly = false;
+
     test("instances don't require the snapshot to include the cache", () => {
       const instance = create(ViewExample, { key: "1", name: "Test" }, readOnly);
       expect(instance.slug).toEqual("test");
@@ -114,6 +117,7 @@ describe("class model snapshotted views", () => {
     //   expect(AllOptionalB.is(instanceB)).toBe(false);
     // });
   });
+
   test("an observable instance saves the view value in a snapshot when changed", () => {
     const instance = ViewExample.create({ key: "1", name: "Test" });
     expect(instance.slug).toEqual("test");

--- a/spec/class-model.spec.ts
+++ b/spec/class-model.spec.ts
@@ -12,7 +12,7 @@ import type {
   ModelPropertiesDeclaration,
   SnapshotIn,
 } from "../src";
-import { flow, getSnapshot, getType, isReadOnlyNode, isStateTreeNode, isType, types } from "../src";
+import { flow, getSnapshot, getType, isReadOnlyNode, isStateTreeNode, isType, snapshottedView, types } from "../src";
 import { ClassModel, action, extend, register, view, volatile, volatileAction } from "../src/class-model";
 import { $identifier } from "../src/symbols";
 import { NameExample } from "./fixtures/NameExample";
@@ -135,6 +135,17 @@ class ExtendedMixedInNameExample extends extendingClassModelMixin(NameExample) {
   }
 }
 
+/**
+ * Example class wth a snapshotted view
+ */
+@register
+class NameExampleWithSnapshottedView extends NameExample {
+  @snapshottedView()
+  get extendedNameLength() {
+    return this.name.length;
+  }
+}
+
 @register
 class AutoIdentified extends ClassModel({ key: types.optional(types.identifier, () => "test") }) {
   testKeyIsAlwaysSet() {
@@ -180,6 +191,7 @@ describe("class models", () => {
     ["mixin'd class model", MixedInNameExample],
     ["extended props class model", ExtendedNameExample],
     ["extended mixin'd props class model", ExtendedMixedInNameExample],
+    ["class model with snapshotted views", NameExampleWithSnapshottedView],
   ])("%s", (_name, NameExample) => {
     test("types are identified as quick types", () => {
       expect(isType(NameExample)).toBe(true);

--- a/spec/getSnapshot.spec.ts
+++ b/spec/getSnapshot.spec.ts
@@ -79,7 +79,7 @@ describe("getSnapshot", () => {
     assert<IsExact<typeof snapshot.map.test_key, SnapshotOut<typeof NamedThing>>>(true);
   });
 
-  test("snapshots an readonly node model instance", () => {
+  test("snapshots a readonly node model instance", () => {
     const instance = TestModel.createReadOnly(TestModelSnapshot);
     const snapshot = getSnapshot(instance);
     verifySnapshot(snapshot);
@@ -93,7 +93,7 @@ describe("getSnapshot", () => {
     assert<IsExact<typeof snapshot.map.test_key, SnapshotOut<typeof NamedThing>>>(true);
   });
 
-  test("snapshots an readonly class model instance", () => {
+  test("snapshots a readonly class model instance", () => {
     const instance = TestClassModel.createReadOnly(TestModelSnapshot);
     const snapshot = getSnapshot(instance);
     verifySnapshot(snapshot);

--- a/src/api.ts
+++ b/src/api.ts
@@ -74,8 +74,7 @@ export {
   unescapeJsonPath,
   walk,
 } from "mobx-state-tree";
-
-export { ClassModel, action, extend, register, view, volatile, volatileAction } from "./class-model";
+export { ClassModel, action, extend, register, view, snapshottedView, volatile, volatileAction } from "./class-model";
 export { getSnapshot } from "./snapshot";
 
 export const isType = (value: any): value is IAnyType => {

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -517,7 +517,10 @@ export const isClassModel = (type: IAnyType): type is IClassModelType<any, any, 
 const buildSnapshottedViewProcessor = (snapshottedViews: SnapshottedViewMetadata[], mstType: MSTIModelType<any, any>) => {
   return mstTypes.snapshotProcessor(mstType, {
     postProcessor(snapshot, node) {
-      if (!node) return snapshot; // FIXME -- undesirable to ever run without a node because we are thusly not putting a snapshot of the view in the snapshot
+      if (!node) {
+        debugger;
+        return snapshot; // FIXME -- undesirable to ever run without a node because we are thusly not putting a snapshot of the view in the snapshot
+      }
       for (const snapshottedView of snapshottedViews) {
         storeViewOnSnapshot(node, snapshottedView, snapshot);
       }

--- a/src/fast-instantiator.ts
+++ b/src/fast-instantiator.ts
@@ -1,24 +1,16 @@
 import { isReferenceType, isUnionType } from "mobx-state-tree";
+import type { IAnyModelType as MSTIAnyModelType, IAnyType as MSTIAnyType } from "mobx-state-tree";
 import { ArrayType, QuickArray } from "./array";
+import type { SnapshottedViewMetadata } from "./class-model";
 import type { FastGetBuilder } from "./fast-getter";
 import { FrozenType } from "./frozen";
 import { MapType, QuickMap } from "./map";
+import { MaybeNullType, MaybeType } from "./maybe";
 import { OptionalType } from "./optional";
 import { ReferenceType, SafeReferenceType } from "./reference";
 import { DateType, IntegerType, LiteralType, SimpleType } from "./simple";
 import { $context, $identifier, $notYetMemoized, $parent, $readOnly, $type } from "./symbols";
 import type { IAnyType, IClassModelType, ValidOptionalValue } from "./types";
-import { MaybeNullType, MaybeType } from "./maybe";
-
-/**
- * Compiles a fast function for taking snapshots and turning them into instances of a class model.
- **/
-export const buildFastInstantiator = <T extends IClassModelType<Record<string, IAnyType>, any, any>>(
-  model: T,
-  fastGetters: FastGetBuilder,
-): T => {
-  return new InstantiatorBuilder(model, fastGetters).build();
-};
 
 type DirectlyAssignableType = SimpleType<any> | IntegerType | LiteralType<any> | DateType;
 const isDirectlyAssignableType = (type: IAnyType): type is DirectlyAssignableType => {
@@ -31,7 +23,10 @@ const isDirectlyAssignableType = (type: IAnyType): type is DirectlyAssignableTyp
   );
 };
 
-class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, any, any>> {
+/**
+ * Compiles a fast class constructor that takes snapshots and turns them into instances of a class model.
+ **/
+export class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, any, any>> {
   aliases = new Map<string, string>();
 
   constructor(
@@ -74,13 +69,18 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
     `);
     }
 
-    const identifierProp = this.model.mstType.identifierAttribute;
+    const modelType = innerModelType(this.model.mstType);
+    const identifierProp = modelType?.identifierAttribute;
     if (identifierProp) {
       segments.push(`
       const id = this["${identifierProp}"];
       this[$identifier] = id;
       context.referenceCache.set(id, this);
     `);
+    }
+
+    for (const [index, snapshottedView] of this.model.snapshottedViews.entries()) {
+      segments.push(this.assignSnapshottedViewExpression(snapshottedView, index));
     }
 
     let className = this.model.name;
@@ -144,7 +144,7 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
     `;
 
     const aliasFuncBody = `
-    const { QuickMap, QuickArray, $identifier, $context, $parent, $notYetMemoized, $readOnly, $type } = imports;
+    const { QuickMap, QuickArray, $identifier, $context, $parent, $notYetMemoized, $readOnly, $type, snapshottedViews } = imports;
 
     ${Array.from(this.aliases.entries())
       .map(([expression, alias]) => `const ${alias} = ${expression};`)
@@ -182,6 +182,7 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
         $notYetMemoized,
         QuickMap,
         QuickArray,
+        snapshottedViews: this.model.snapshottedViews,
       }) as T;
     } catch (e) {
       console.warn("failed to build fast instantiator for", this.model.name);
@@ -331,6 +332,25 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
       }`;
   }
 
+  private assignSnapshottedViewExpression(snapshottedView: SnapshottedViewMetadata, index: number) {
+    const varName = `view${snapshottedView.property}`;
+
+    let valueExpression = `snapshot?.["${snapshottedView.property}"]`;
+    if (snapshottedView.options.createReadOnly) {
+      const alias = this.alias(`snapshottedViews[${index}].options.createReadOnly`);
+      valueExpression = `${alias}(${valueExpression}, snapshot, this)`;
+    }
+    const memoSymbolAlias = this.alias(`Symbol.for("${this.getters.memoSymbolName(snapshottedView.property)}")`);
+
+    return `
+      // setup snapshotted view for ${snapshottedView.property}
+      const ${varName} = ${valueExpression};
+      if (typeof ${varName} != "undefined") {
+        this[${memoSymbolAlias}] = ${varName};
+      }
+    `;
+  }
+
   alias(expression: string): string {
     const existing = this.aliases.get(expression);
     if (existing) {
@@ -344,3 +364,17 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
 }
 
 const safeTypeName = (type: IAnyType) => type.name.replace(/\n/g, "");
+
+const innerModelType = (type: MSTIAnyType): MSTIAnyModelType | undefined => {
+  if ("identifierAttribute" in type) return type as MSTIAnyModelType;
+  if ("getSubTypes" in type) {
+    const subTypes = (type as { getSubTypes(): MSTIAnyType[] | MSTIAnyType | null }).getSubTypes();
+    if (subTypes) {
+      if (Array.isArray(subTypes)) {
+        return innerModelType(subTypes[0]);
+      } else if (subTypes && typeof subTypes == "object") {
+        return innerModelType(subTypes);
+      }
+    }
+  }
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { IInterceptor, IMapDidChange, IMapWillChange, Lambda } from "mobx";
 import type { IAnyType as MSTAnyType } from "mobx-state-tree";
-import type { VolatileMetadata } from "./class-model";
+import type { SnapshottedViewMetadata, VolatileMetadata } from "./class-model";
 import type { $quickType, $registered, $type } from "./symbols";
 
 export type { $quickType, $registered, $type } from "./symbols";
@@ -146,6 +146,8 @@ export interface IClassModelType<
 
   /** @hidden */
   volatiles: Record<string, VolatileMetadata>;
+  /** @hidden */
+  snapshottedViews: SnapshottedViewMetadata[];
 
   /** @hidden */
   instantiate(snapshot: this["InputType"] | undefined, context: TreeContext, parent: IStateTreeNode | null): InstanceType<this>;


### PR DESCRIPTION
This adds a feature for caching the output of a view in the snapshot of a node. For expensive views, it's nice to compute them at write time, serialize their return values, and then deserialize them in all the readonly contexts instead of computing them. For things like Gadget's action options (or even the string operations to produce the api identifier), we're already computing them once, we can cache that through the snapshot and avoid recomputing them on every read only root. Not all views are snapshotted; you opt in with a `@snapshottedView()` decorator. 

As an example, say we have this class:

```typescript
@register
class ViewExample extends ClassModel({ key: types.identifier, name: types.string }) {
  @snapshottedView()
  get slug() {
    return this.name.toLowerCase().replace(/ /g, "-");
  }

  @action
  setName(name: string) {
    this.name = name;
  }
}
```

And I change some stuff about it, the snapshot will contain the computed slug in it::

```typescript
const instance = ViewExample.create({ key: "123", name: "Foous Barius"})
instance.setName("A different name");
const snap = getSnapshot(instance); // => { key: "123", name: "A different name", slug: "a-different-name"}
```

Then, if I create a readonly instance from that snapshot, I can ask for the slug, and the cached value will be returned right away, without calling the view function:

```typescript
const readOnlyInstance = ViewExample.createReadOnly(snap);
readOnlyInstance.slug // => "a-different-name", much faster
```

Yay!

### The details

The devil for this one is in the deep and frankly super intense details about how and when exactly these computations happen. Here's some decision points:

__Must all snapshots have the value for all snapshotted views?__

I vote no so that this feature is incrementally adoptable. If you have a bunch of stored snapshots without a view in them, and then switch a view over to be snapshotted, ideally, the old stored snapshots still work. We have a way to compute the view in both read-only and observable instances that already has nice pure / safe properties, so I think these properties should be optional in the snapshot. 

__What if the definition of the view changes such that recomputing it would produce a different value than the snapshot?__

A great question. Rephrased, this is also asking "what if the incoming snapshot lies about the view value", and the answer is that detecting lies is expensive. We could recompute the view to see if it is correct, but that defeats the performance-win purpose of the cache in the first place. We could store some version number or sigil in the snapshot itself, and only use the value if the version matches, but that seems complicated, and like it would cause some surprise performance issues where code changes all of a sudden caused the caches to stop hitting, but not necessarily cause them to be re-filled with up to date data, getting us stuck in a poor-er performing spot. 

So, I opted to just trust the snapshot, and rely on whatever the thing feeding in the snapshot is to feed in a new one when required. In Gadget's case, the environment version mechanism around a ROSR cache should serve this purpose well, but not everyone else is gonna have that. I think this is a super advanced feature that is ok to have barbs like this.

__Should observable instances care about the value in the snapshot?__

For read-only instances, we should use the snapshot value to avoid running the view and improve performance. But for observable instances, we could "seed" the view with the initial value from the snapshot, or we could just ignore it, and recompute on demand. I think that because of the above view-definition/snapshot-value drift problem, we should do this computation and take the hit. It's also kinda complicated to seed the value of a computed like this, but I am sure we could make it work if we had to. I kinda like the distinction of "observable instances are the authority and work in the pure, nice way that MST does", and "readonly instances are bastardized to all hell to make them as performant as possible, which is ok, because they are readonly and wont ever be written back to disk".

__Right after observable instance creation, should the snapshot have the snapshotted views in it?__

With the following class model:

```typescript
@register
class ViewExample extends ClassModel({ key: types.identifier, name: types.string }) {
  @snapshottedView()
  get slug() {
    return this.name.toLowerCase().replace(/ /g, "-");
  }

  @action
  setName(name: string) {
    this.name = name;
  }
}
```

I can do this to ask for the initial snapshot of the instance:

```typescript
const instance = ViewExample.create({ key: "123", name: "Foous Barius"})
getSnapshot(instance);
```

Before snapshotted views ever existed, this pattern could be super performant and just return exactly the input snapshot. Now though, we could say that all snapshots alwas have the value of snapshotted views in them, so that initial `getSnapshot` call *needs* to execute the snapshotted views in order to get values for the snapshot. We could say that "if a view hasn't been touched, it won't be in the snapshot", such that snapshots only sometimes have the snapshotted views in them. This would work technically, but I think defeat our purposes Gadget side. Many of our persisters just store `getSnapshot(someInstance)` in a jsonb column, and if MQT doesn't feed in the snapshotted views into that column, the ROSR won't ever get them to improve performance. So, I think we should make the rule "all snapshots have snapshotted views in them" for simplicity and predictability.


Gadget side PR showing how it might be used: https://github.com/gadget-inc/gadget/pull/8902

mobx-state-tree bugs:
 - https://github.com/mobxjs/mobx-state-tree/pull/2183
 - https://github.com/mobxjs/mobx-state-tree/pull/2182