### PR TITLE
Upgrade mobx-state-tree version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/mobx-quick-tree",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A mirror of mobx-state-tree's API to construct fast, read-only instances that share all the same views",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
@@ -28,7 +28,7 @@
   "dependencies": {
     "lodash.memoize": "^4.1.2",
     "mobx": "^6.5.0",
-    "mobx-state-tree": "^5.1.3",
+    "mobx-state-tree": "^5.3.0",
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^6.5.0
     version: 6.8.0
   mobx-state-tree:
-    specifier: ^5.1.3
-    version: 5.1.8(mobx@6.8.0)
+    specifier: ^5.3.0
+    version: 5.3.0(mobx@6.8.0)
   reflect-metadata:
     specifier: ^0.1.13
     version: 0.1.13
@@ -3760,8 +3760,8 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /mobx-state-tree@5.1.8(mobx@6.8.0):
-    resolution: {integrity: sha512-oe82BNgMr408e6DxMDNat8msXQTuyuqzJ97DPupbhchEfjjHyjsmPSwtXHl+nXiW3tybpb/cr5siUClBqKqv+Q==}
+  /mobx-state-tree@5.3.0(mobx@6.8.0):
+    resolution: {integrity: sha512-2XInCjIxGQx/UmTbpAreWKcHswmuOKOV23HJmy1x4gqyDqCcOHJcaClpWnD2/qQlGncg8gAUfP/mm+cLpTrtlQ==}
     peerDependencies:
       mobx: ^6.3.0
     dependencies:

--- a/src/enumeration.ts
+++ b/src/enumeration.ts
@@ -5,7 +5,7 @@ import memoize from "lodash.memoize";
 
 class EnumerationType<EnumOptions extends string> extends BaseType<EnumOptions, EnumOptions, EnumOptions> {
   constructor(readonly name: string, readonly options: readonly EnumOptions[]) {
-    super(types.enumeration<EnumOptions>([...options]));
+    super(types.enumeration<EnumOptions>(name, [...options]));
   }
 
   instantiate(snapshot: this["InputType"], _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {


### PR DESCRIPTION
I want to get the faster constructor patch into Gadget, as well as upgrade MST separately from #69. This PR would cut a new release of MQT with the newest MST and the faster constructor logic. No changes to the supported node version, so we shouldn't notice any regression in Gadget (yet).

Some small perf wins in MST 5.3.0 for the observable side too!

Gadget side integration PR: https://github.com/gadget-inc/gadget/pull/8915