### PR TITLE
Add a sourceURL to eval'd code so sourcemap aware things pick up the dynamic function name

### DIFF
--- a/src/fast-instantiator.ts
+++ b/src/fast-instantiator.ts
@@ -152,7 +152,14 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
       // build a function that closes over a bunch of aliased expressions
       // evaluate the inner function source code in this closure to return the function
       // eslint-disable-next-line @typescript-eslint/no-implied-eval
-      const aliasFunc = new Function("model", "imports", aliasFuncBody);
+      const aliasFunc = eval(`
+        (
+          function buildFastInstantiator(model, imports) {
+            ${aliasFuncBody}
+          }
+        )
+        //# sourceURL=mqt-eval/dynamic/${className}.js
+      `);
 
       // evaluate aliases and get created inner function
       return aliasFunc(this.model, { $identifier, $env, $parent, $memos, $memoizedKeys, $readOnly, $type, QuickMap, QuickArray }) as T;


### PR DESCRIPTION
This makes stack traces and some profiling tools aware of the filename of the eval'd code. In jest, errors now look like this:

```
  ● clas model references › safe references are equal to the instances they refer to

    whatever

      at new Root (mqt-eval/dynamic/Root.js:51:17)
      at Function.createReadOnly (mqt-eval/dynamic/Root.js:22:28)
      at createReadOnly (spec/helpers.ts:6:17)
      at Object.<anonymous> (spec/class-model-references.spec.ts:148:24)
```

Flamegraph sadly didn't pick this up but maybe some other tools will -- may as well set it?

Woop woop!
