### PR TITLE
Implement `resolveIdentifier` on readonly trees

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -2,8 +2,8 @@ import { isStateTreeNode, types } from "mobx-state-tree";
 import { BaseType } from "./base";
 import { ensureRegistered } from "./class-model";
 import { getSnapshot } from "./snapshot";
-import { $env, $parent, $readOnly, $type } from "./symbols";
-import type { IAnyStateTreeNode, IAnyType, IArrayType, IMSTArray, IStateTreeNode, Instance, InstantiateContext } from "./types";
+import { $context, $parent, $readOnly, $type } from "./symbols";
+import type { IAnyStateTreeNode, IAnyType, IArrayType, IMSTArray, IStateTreeNode, Instance, TreeContext } from "./types";
 
 export class QuickArray<T extends IAnyType> extends Array<Instance<T>> implements IMSTArray<T> {
   static get [Symbol.species]() {
@@ -11,17 +11,17 @@ export class QuickArray<T extends IAnyType> extends Array<Instance<T>> implement
   }
 
   /** @hidden */
-  readonly [$env]: any;
+  readonly [$context]: any;
   /** @hidden */
   readonly [$parent]: IStateTreeNode | null;
   /** @hidden */
   readonly [$type]: [this] | [any];
 
-  constructor(type: any, parent: IStateTreeNode | null, env: any, ...items: Instance<T>[]) {
+  constructor(type: any, parent: IStateTreeNode | null, context: TreeContext, ...items: Instance<T>[]) {
     super(...items);
     this[$type] = type;
     this[$parent] = parent;
-    this[$env] = env;
+    this[$context] = context;
   }
 
   get [Symbol.toStringTag]() {
@@ -79,8 +79,8 @@ export class ArrayType<T extends IAnyType> extends BaseType<Array<T["InputType"]
     return value.every((child: any) => this.childrenType.is(child));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
-    const array = new QuickArray<T>(this, parent, context.env);
+  instantiate(snapshot: this["InputType"] | undefined, context: TreeContext, parent: IStateTreeNode | null): this["InstanceType"] {
+    const array = new QuickArray<T>(this, parent, context);
     if (snapshot) {
       for (let index = 0; index < snapshot?.length; ++index) {
         array.push(this.childrenType.instantiate(snapshot[index], context, array));

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,6 +1,6 @@
 import type { IAnyType as MSTAnyType } from "mobx-state-tree";
 import { $quickType } from "./symbols";
-import type { IAnyStateTreeNode, IStateTreeNode, InstantiateContext, StateTreeNode } from "./types";
+import type { IAnyStateTreeNode, IStateTreeNode, TreeContext, StateTreeNode } from "./types";
 
 export abstract class BaseType<InputType, OutputType, InstanceType> {
   readonly [$quickType] = undefined;
@@ -38,7 +38,7 @@ export abstract class BaseType<InputType, OutputType, InstanceType> {
    * Create a new instance of this class model in readonly mode. Properties and views are accessible on readonly instances but actions will throw if run.
    */
   createReadOnly(snapshot?: InputType, env?: any): this["InstanceType"] {
-    const context: InstantiateContext = {
+    const context: TreeContext = {
       referenceCache: new Map(),
       referencesToResolve: [],
       env,
@@ -52,11 +52,7 @@ export abstract class BaseType<InputType, OutputType, InstanceType> {
     return instance;
   }
 
-  abstract instantiate(
-    snapshot: this["InputType"] | undefined,
-    context: InstantiateContext,
-    parent: IStateTreeNode | null
-  ): this["InstanceType"];
+  abstract instantiate(snapshot: this["InputType"] | undefined, context: TreeContext, parent: IStateTreeNode | null): this["InstanceType"];
 
   abstract schemaHash(): Promise<string>;
 }

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -6,7 +6,7 @@ import { RegistrationError } from "./errors";
 import { buildFastInstantiator } from "./fast-instantiator";
 import { defaultThrowAction, mstPropsFromQuickProps, propsFromModelPropsDeclaration } from "./model";
 import {
-  $env,
+  $context,
   $identifier,
   $memoizedKeys,
   $memos,
@@ -25,7 +25,7 @@ import type {
   IAnyType,
   IClassModelType,
   IStateTreeNode,
-  InstantiateContext,
+  TreeContext,
   ModelPropertiesDeclaration,
   ModelViews,
   TypesForModelPropsDeclaration,
@@ -84,7 +84,7 @@ class BaseClassModel {
   [$readOnly]!: true;
   [$type]!: IClassModelType<TypesForModelPropsDeclaration<any>>;
   /** @hidden */
-  readonly [$env]?: any;
+  readonly [$context]?: any;
   /** @hidden */
   readonly [$parent]?: IStateTreeNode | null;
   /** @hidden */

--- a/src/custom.ts
+++ b/src/custom.ts
@@ -1,14 +1,14 @@
 import type { CustomTypeOptions } from "mobx-state-tree";
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { IStateTreeNode, IType, InstantiateContext } from "./types";
+import type { IStateTreeNode, IType, TreeContext } from "./types";
 
 export class CustomType<InputType, OutputType> extends BaseType<InputType, OutputType, OutputType> {
   constructor(readonly options: CustomTypeOptions<InputType, OutputType>) {
     super(types.custom<InputType, OutputType>(options));
   }
 
-  instantiate(snapshot: InputType, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: InputType, context: TreeContext, parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot === undefined) {
       throw new Error("can't initialize custom type with undefined");
     }

--- a/src/enumeration.ts
+++ b/src/enumeration.ts
@@ -1,6 +1,6 @@
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { IAnyStateTreeNode, InstantiateContext, ISimpleType, IStateTreeNode } from "./types";
+import type { IAnyStateTreeNode, TreeContext, ISimpleType, IStateTreeNode } from "./types";
 import memoize from "lodash.memoize";
 
 class EnumerationType<EnumOptions extends string> extends BaseType<EnumOptions, EnumOptions, EnumOptions> {
@@ -8,7 +8,7 @@ class EnumerationType<EnumOptions extends string> extends BaseType<EnumOptions, 
     super(types.enumeration<EnumOptions>(name, [...options]));
   }
 
-  instantiate(snapshot: this["InputType"], _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"], _context: TreeContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (typeof snapshot == "string" && this.options.includes(snapshot)) {
       return snapshot as this["InstanceType"];
     }

--- a/src/frozen.ts
+++ b/src/frozen.ts
@@ -1,13 +1,13 @@
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { InstantiateContext, ISimpleType, IStateTreeNode } from "./types";
+import type { TreeContext, ISimpleType, IStateTreeNode } from "./types";
 
 export class FrozenType<T> extends BaseType<T, T, T> {
   constructor() {
     super(types.frozen<T>());
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, _context: TreeContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (typeof snapshot == "function") {
       throw new Error("frozen types can't be instantiated with functions");
     }

--- a/src/late.ts
+++ b/src/late.ts
@@ -1,7 +1,7 @@
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
 import { ensureRegistered } from "./class-model";
-import type { IAnyType, IStateTreeNode, InstanceWithoutSTNTypeForType, InstantiateContext } from "./types";
+import type { IAnyType, IStateTreeNode, InstanceWithoutSTNTypeForType, TreeContext } from "./types";
 
 class LateType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputType"], InstanceWithoutSTNTypeForType<T>> {
   private cachedType: T | null | undefined;
@@ -10,7 +10,7 @@ class LateType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputTyp
     super(types.late<T["mstType"]>(`late(${fn.toString()})`, () => this.type?.mstType as T["mstType"]));
   }
 
-  instantiate(snapshot: this["InputType"], context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"], context: TreeContext, parent: IStateTreeNode | null): this["InstanceType"] {
     return this.type.instantiate(snapshot, context, parent);
   }
 

--- a/src/map.ts
+++ b/src/map.ts
@@ -3,7 +3,7 @@ import { isStateTreeNode, types } from "mobx-state-tree";
 import { BaseType } from "./base";
 import { ensureRegistered } from "./class-model";
 import { getSnapshot } from "./snapshot";
-import { $env, $parent, $readOnly, $type } from "./symbols";
+import { $context, $parent, $readOnly, $type } from "./symbols";
 import type {
   CreateTypes,
   IAnyStateTreeNode,
@@ -12,7 +12,7 @@ import type {
   IMapType,
   IStateTreeNode,
   Instance,
-  InstantiateContext,
+  TreeContext,
   SnapshotOut,
 } from "./types";
 
@@ -22,17 +22,17 @@ export class QuickMap<T extends IAnyType> extends Map<string, Instance<T>> imple
   }
 
   /** @hidden */
-  readonly [$env]?: any;
+  readonly [$context]?: any;
   /** @hidden */
   readonly [$parent]?: IStateTreeNode | null;
   /** @hidden */
   readonly [$type]?: [this] | [any];
 
-  constructor(type: any, parent: IStateTreeNode | null, env: any) {
+  constructor(type: any, parent: IStateTreeNode | null, context: TreeContext) {
     super();
     this[$type] = type;
     this[$parent] = parent;
-    this[$env] = env;
+    this[$context] = context;
   }
 
   get [Symbol.toStringTag]() {
@@ -107,8 +107,8 @@ export class MapType<T extends IAnyType> extends BaseType<
     return children.every((child) => this.childrenType.is(child));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
-    const map = new QuickMap<T>(this, parent, context.env);
+  instantiate(snapshot: this["InputType"] | undefined, context: TreeContext, parent: IStateTreeNode | null): this["InstanceType"] {
+    const map = new QuickMap<T>(this, parent, context);
     if (snapshot) {
       for (const key in snapshot) {
         const item = this.childrenType.instantiate(snapshot[key], context, map);

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -8,7 +8,7 @@ import type {
   IMaybeType,
   IStateTreeNode,
   InstanceWithoutSTNTypeForType,
-  InstantiateContext,
+  TreeContext,
 } from "./types";
 
 class MaybeType<Type extends IAnyType> extends BaseType<
@@ -20,7 +20,7 @@ class MaybeType<Type extends IAnyType> extends BaseType<
     super(mstTypes.maybe(type.mstType));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, context: TreeContext, parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot === undefined) {
       return undefined;
     }
@@ -48,7 +48,7 @@ class MaybeNullType<Type extends IAnyType> extends BaseType<
     super(mstTypes.maybeNull(type.mstType));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, context: TreeContext, parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot === undefined || snapshot === null) {
       // Special case for things like types.frozen, or types.literal(undefined), where MST prefers the subtype over maybeNull
       if (this.type.is(snapshot)) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -5,7 +5,7 @@ import { types } from ".";
 import { BaseType } from "./base";
 import { ensureRegistered } from "./class-model";
 import { CantRunActionError } from "./errors";
-import { $env, $identifier, $originalDescriptor, $parent, $readOnly, $type } from "./symbols";
+import { $context, $identifier, $originalDescriptor, $parent, $readOnly, $type } from "./symbols";
 import type {
   IAnyStateTreeNode,
   IAnyType,
@@ -15,7 +15,7 @@ import type {
   InputsForModel,
   Instance,
   InstanceTypesForModelProps,
-  InstantiateContext,
+  TreeContext,
   ModelActions,
   ModelProperties,
   ModelPropertiesDeclaration,
@@ -92,7 +92,7 @@ export const instantiateInstanceFromProperties = (
   snapshot: Record<string, any> | undefined,
   properties: ModelProperties,
   identifierProp: string | undefined,
-  context: InstantiateContext
+  context: TreeContext
 ) => {
   for (const propName in properties) {
     const propType = properties[propName];
@@ -161,7 +161,7 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
         enumerable: false,
         writable: true,
       },
-      [$env]: {
+      [$context]: {
         value: null,
         configurable: false,
         enumerable: false,
@@ -260,7 +260,7 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
     return true;
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, context: TreeContext, parent: IStateTreeNode | null): this["InstanceType"] {
     const instance: Record<string | symbol, any> = Object.create(this.prototype, {
       [$parent]: {
         value: parent,
@@ -268,8 +268,8 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
         configurable: false,
         writable: false,
       },
-      [$env]: {
-        value: context.env,
+      [$context]: {
+        value: context,
         enumerable: false,
         configurable: false,
         writable: false,

--- a/src/optional.ts
+++ b/src/optional.ts
@@ -6,7 +6,7 @@ import type {
   IAnyStateTreeNode,
   IAnyType,
   InstanceWithoutSTNTypeForType,
-  InstantiateContext,
+  TreeContext,
   IOptionalType,
   IStateTreeNode,
   ValidOptionalValue,
@@ -30,7 +30,7 @@ export class OptionalType<
     );
   }
 
-  instantiate(snapshot: this["InputType"], context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"], context: TreeContext, parent: IStateTreeNode | null): this["InstanceType"] {
     if (this.undefinedValues) {
       if (this.undefinedValues.includes(snapshot)) {
         snapshot = this.defaultValue;

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -10,7 +10,7 @@ import type {
   IReferenceType,
   IStateTreeNode,
   InstanceWithoutSTNTypeForType,
-  InstantiateContext,
+  TreeContext,
 } from "./types";
 import memoize from "lodash.memoize";
 
@@ -28,7 +28,7 @@ export class ReferenceType<TargetType extends IAnyComplexType> extends BaseType<
     super(types.reference(targetType.mstType, options));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, context: TreeContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (!snapshot || !context.referenceCache.has(snapshot)) {
       throw new Error(`can't resolve reference ${snapshot}`);
     }
@@ -54,7 +54,7 @@ export class SafeReferenceType<TargetType extends IAnyComplexType> extends BaseT
     super(types.safeReference(targetType.mstType, options));
   }
 
-  instantiate(snapshot: string | undefined, context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: string | undefined, context: TreeContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (!snapshot || !context.referenceCache.has(snapshot)) {
       return undefined as this["InstanceType"];
     }

--- a/src/refinement.ts
+++ b/src/refinement.ts
@@ -1,14 +1,14 @@
 import type { Instance } from "mobx-state-tree";
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { IAnyType, InstanceWithoutSTNTypeForType, InstantiateContext, IStateTreeNode, IType } from "./types";
+import type { IAnyType, InstanceWithoutSTNTypeForType, TreeContext, IStateTreeNode, IType } from "./types";
 
 class RefinementType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputType"], InstanceWithoutSTNTypeForType<T>> {
   constructor(readonly type: T, readonly predicate: (snapshot: Instance<T> | Instance<T["mstType"]>) => boolean) {
     super(types.refinement(type.mstType, predicate));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, context: TreeContext, parent: IStateTreeNode | null): this["InstanceType"] {
     const instance = this.type.instantiate(snapshot, context, parent);
     if (!this.predicate(instance)) {
       throw new Error("given snapshot isn't valid for refinement type");

--- a/src/simple.ts
+++ b/src/simple.ts
@@ -1,7 +1,7 @@
 import type { ISimpleType as MSTSimpleType } from "mobx-state-tree";
 import { types } from "mobx-state-tree";
 import { BaseType } from "./base";
-import type { InstantiateContext, ISimpleType, IStateTreeNode } from "./types";
+import type { TreeContext, ISimpleType, IStateTreeNode } from "./types";
 
 export type Primitives = string | number | boolean | Date | null | undefined;
 
@@ -14,7 +14,7 @@ export class SimpleType<T> extends BaseType<T, T, T> {
     super(mstType);
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, _context: TreeContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot === undefined) {
       throw new Error(`can't initialize simple type ${this.name} with undefined`);
     }
@@ -32,7 +32,7 @@ export class SimpleType<T> extends BaseType<T, T, T> {
 }
 
 export class DateType extends BaseType<Date | number, number, Date> {
-  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, _context: TreeContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot === undefined) {
       throw new Error(`can't initialize simple type ${this.name} with undefined`);
     }
@@ -55,7 +55,7 @@ export class IntegerType extends BaseType<number, number, number> {
     super(types.integer);
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, _context: TreeContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (!Number.isInteger(snapshot)) {
       throw new Error(`can't initialize integer with ${snapshot}`);
     }
@@ -78,7 +78,7 @@ export class NullType extends BaseType<null, null, null> {
     super(types.null);
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, _context: TreeContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot !== null) {
       throw new Error(`can't initialize null with ${snapshot}`);
     }
@@ -101,7 +101,7 @@ export class LiteralType<T extends Primitives> extends SimpleType<T> {
     super(typeof value, types.literal<T>(value));
   }
 
-  instantiate(snapshot: this["InputType"] | undefined, _context: InstantiateContext, _parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"] | undefined, _context: TreeContext, _parent: IStateTreeNode | null): this["InstanceType"] {
     if (snapshot !== this.value) {
       throw new Error(`expected literal type to be initialized with ${this.value}`);
     }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -2,7 +2,7 @@
 export const $quickType = Symbol.for("MQT_quickType");
 
 /** @hidden */
-export const $env = Symbol.for("MQT_env");
+export const $context = Symbol.for("MQT_context");
 
 /** @hidden */
 export const $parent = Symbol.for("MQT_parent");

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface IType<InputType, OutputType, InstanceType> {
   createReadOnly(snapshot?: InputType, env?: any): this["InstanceType"];
 
   /** @hidden */
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"];
+  instantiate(snapshot: this["InputType"] | undefined, context: TreeContext, parent: IStateTreeNode | null): this["InstanceType"];
 
   /** Get a string hash for the schema of this type */
   schemaHash(): Promise<string>;
@@ -148,7 +148,7 @@ export interface IClassModelType<
   volatiles: Record<string, VolatileMetadata>;
 
   /** @hidden */
-  instantiate(snapshot: this["InputType"] | undefined, context: InstantiateContext, parent: IStateTreeNode | null): InstanceType<this>;
+  instantiate(snapshot: this["InputType"] | undefined, context: TreeContext, parent: IStateTreeNode | null): InstanceType<this>;
 
   is(value: IAnyStateTreeNode): value is InstanceType<this>;
   is(value: any): value is this["InputType"] | InstanceType<this>;
@@ -251,7 +251,7 @@ export interface IMSTMap<T extends IAnyType> {
 }
 
 /** @hidden */
-export interface InstantiateContext {
+export interface TreeContext {
   referenceCache: Map<string, Instance<IAnyNodeModelType>>;
   referencesToResolve: (() => void)[];
   env?: unknown;

--- a/src/union.ts
+++ b/src/union.ts
@@ -3,7 +3,7 @@ import type { UnionOptions as MSTUnionOptions } from "mobx-state-tree";
 import { types as mstTypes } from "mobx-state-tree";
 import { BaseType } from "./base";
 import { ensureRegistered, isClassModel } from "./class-model";
-import type { IAnyType, InstanceWithoutSTNTypeForType, InstantiateContext, IStateTreeNode, IUnionType } from "./types";
+import type { IAnyType, InstanceWithoutSTNTypeForType, TreeContext, IStateTreeNode, IUnionType } from "./types";
 import { OptionalType } from "./optional";
 import { isModelType, isType } from "./api";
 import { LiteralType } from "./simple";
@@ -24,7 +24,7 @@ export interface UnionOptions extends Omit<MSTUnionOptions, "dispatcher"> {
   dispatcher?: ITypeDispatcher;
 }
 
-const emptyContext: InstantiateContext = {
+const emptyContext: TreeContext = {
   referenceCache: new Map(),
   referencesToResolve: [],
 };
@@ -114,7 +114,7 @@ class UnionType<Types extends IAnyType[]> extends BaseType<
     this.dispatcher = dispatcher;
   }
 
-  instantiate(snapshot: this["InputType"], context: InstantiateContext, parent: IStateTreeNode | null): this["InstanceType"] {
+  instantiate(snapshot: this["InputType"], context: TreeContext, parent: IStateTreeNode | null): this["InstanceType"] {
     let type: Types[number] | undefined;
     if (this.dispatcher) {
       type = this.dispatcher(snapshot);


### PR DESCRIPTION
Got a `not yet implemented` gadget side when going to use this API, figured it wasn't too hard! We implement by keeping the identifier cache around beyond just after we instantiate, instead of only capturing a reference to the env from that context. 