### PR TITLE
chore(bench): update CodSpeed/action to v2

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
       - uses: ./.github/actions/setup-test-env
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v1
+        uses: CodSpeedHQ/action@v2
         with:
           run: node --version && pnpm x bench/all.ts
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
Upgrading to the v2 of https://github.com/CodSpeedHQ/action will bring a better base run selection algorithm, better logging, and continued support.