### PR TITLE
Ensure we properly snapshot reference types in maps/arrays

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -1,8 +1,8 @@
 import type { IStateTreeNode as MSTStateTreeNode } from "mobx-state-tree";
 import { getSnapshot as mstGetSnapshot, isStateTreeNode as mstIsStateTreeNode } from "mobx-state-tree";
 import { getType, isModelType, isReferenceType, isStateTreeNode } from "./api";
-import { QuickArray } from "./array";
-import { QuickMap } from "./map";
+import { ArrayType, QuickArray } from "./array";
+import { MapType, QuickMap } from "./map";
 import { $identifier } from "./symbols";
 import type { IAnyType, IStateTreeNode, SnapshotOut } from "./types";
 
@@ -16,11 +16,21 @@ export function getSnapshot<T extends IAnyType>(value: IStateTreeNode<T>): Snaps
 
 const snapshot = (value: any): unknown => {
   if (value instanceof QuickArray) {
-    return Array.from(value.map((v) => snapshot(v)));
+    const type = getType(value) as ArrayType<IAnyType>;
+    const childrenAreReferences = isReferenceType(type.childrenType);
+
+    return Array.from(value.map((v) => (childrenAreReferences ? v[$identifier] : snapshot(v))));
   }
 
   if (value instanceof QuickMap) {
-    return Object.fromEntries(Array.from(value.entries()).map(([k, v]) => [k, snapshot(v)]));
+    const type = getType(value) as MapType<IAnyType>;
+    const childrenAreReferences = isReferenceType(type.childrenType);
+
+    return Object.fromEntries(
+      Array.from(value.entries()).map(([k, v]) => {
+        return [k, childrenAreReferences ? v[$identifier] : snapshot(v)];
+      })
+    );
   }
 
   if (value instanceof Date) {


### PR DESCRIPTION
The snapshot type for a reference should be `string | number`, although we set it as just string in MQT:

![CleanShot 2024-05-08 at 18 01 39@2x](https://github.com/gadget-inc/mobx-quick-tree/assets/833576/f42d84bb-f1bf-4d19-a7bb-d41239950db6)

But when we have a reference type in a map/array, we currently return the referenced object value itself, not its identifier. If someone then tries to construct an object from this snapshot, 💥.

This adds a special case in our snapshotter for `types.map` and `types.array` to check the children type first. If a reference type, we pull out the identifier, otherwise we do the regular snapshotting of children.

I saw this when doing some testing in Gadget, and got this:

![CleanShot 2024-05-08 at 18 07 20@2x](https://github.com/gadget-inc/mobx-quick-tree/assets/833576/c394f7fb-75f3-4797-9c9b-7fe403b15e12)
