### PR TITLE
Update all dependencies + fix ensureRegistered bug

### DIFF
--- a/bench/all.ts
+++ b/bench/all.ts
@@ -46,4 +46,7 @@ void suite
   .on("complete", function (this: Suite) {
     console.profileEnd();
   })
-  .run({ async: true });
+  .run({
+    async: true,
+    initCount: 100
+  });

--- a/package.json
+++ b/package.json
@@ -27,22 +27,22 @@
   },
   "dependencies": {
     "lodash.memoize": "^4.1.2",
-    "mobx": "^6.5.0",
-    "mobx-state-tree": "^5.3.0",
-    "reflect-metadata": "^0.1.13"
+    "mobx": "^6.12.3",
+    "mobx-state-tree": "^6.0.0",
+    "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
-    "@codspeed/benchmark.js-plugin": "^2.2.0",
-    "@faker-js/faker": "^7.6.0",
+    "@codspeed/benchmark.js-plugin": "^3.1.0",
+    "@faker-js/faker": "^8.4.1",
     "@gadgetinc/eslint-config": "^0.6.1",
     "@gadgetinc/prettier-config": "^0.4.0",
-    "@swc/core": "^1.3.96",
-    "@swc/jest": "^0.2.29",
+    "@swc/core": "^1.5.5",
+    "@swc/jest": "^0.2.36",
     "@types/benchmark": "^2.1.5",
     "@types/find-root": "^1.1.4",
-    "@types/jest": "^29.5.8",
+    "@types/jest": "^29.5.12",
     "@types/lodash.memoize": "^4.1.9",
-    "@types/node": "^18.18.9",
+    "@types/node": "^20.12.11",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "benchmark": "^2.1.4",
@@ -56,9 +56,9 @@
     "jest": "^29.7.0",
     "lodash": "^4.17.21",
     "microtime": "^3.1.1",
-    "prettier": "^2.8.8",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.2.2"
+    "prettier": "^3.2.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
   },
   "volta": {
     "node": "18.12.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,34 +9,34 @@ dependencies:
     specifier: ^4.1.2
     version: 4.1.2
   mobx:
-    specifier: ^6.5.0
-    version: 6.8.0
+    specifier: ^6.12.3
+    version: 6.12.3
   mobx-state-tree:
-    specifier: ^5.3.0
-    version: 5.3.0(mobx@6.8.0)
+    specifier: ^6.0.0
+    version: 6.0.0(mobx@6.12.3)
   reflect-metadata:
-    specifier: ^0.1.13
-    version: 0.1.13
+    specifier: ^0.2.2
+    version: 0.2.2
 
 devDependencies:
   '@codspeed/benchmark.js-plugin':
-    specifier: ^2.2.0
-    version: 2.2.0(benchmark@2.1.4)
+    specifier: ^3.1.0
+    version: 3.1.0(benchmark@2.1.4)
   '@faker-js/faker':
-    specifier: ^7.6.0
-    version: 7.6.0
+    specifier: ^8.4.1
+    version: 8.4.1
   '@gadgetinc/eslint-config':
     specifier: ^0.6.1
-    version: 0.6.1(@gadgetinc/prettier-config@0.4.0)(eslint@8.53.0)(jest@29.7.0)(lodash@4.17.21)(typescript@5.2.2)
+    version: 0.6.1(@gadgetinc/prettier-config@0.4.0)(eslint@8.57.0)(jest@29.7.0)(lodash@4.17.21)(typescript@5.4.5)
   '@gadgetinc/prettier-config':
     specifier: ^0.4.0
-    version: 0.4.0(prettier@2.8.8)(typescript@5.2.2)
+    version: 0.4.0(prettier@3.2.5)(typescript@5.4.5)
   '@swc/core':
-    specifier: ^1.3.96
-    version: 1.3.96
+    specifier: ^1.5.5
+    version: 1.5.5
   '@swc/jest':
-    specifier: ^0.2.29
-    version: 0.2.29(@swc/core@1.3.96)
+    specifier: ^0.2.36
+    version: 0.2.36(@swc/core@1.5.5)
   '@types/benchmark':
     specifier: ^2.1.5
     version: 2.1.5
@@ -44,20 +44,20 @@ devDependencies:
     specifier: ^1.1.4
     version: 1.1.4
   '@types/jest':
-    specifier: ^29.5.8
-    version: 29.5.8
+    specifier: ^29.5.12
+    version: 29.5.12
   '@types/lodash.memoize':
     specifier: ^4.1.9
     version: 4.1.9
   '@types/node':
-    specifier: ^18.18.9
-    version: 18.18.9
+    specifier: ^20.12.11
+    version: 20.12.11
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.62.0
-    version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.53.0)(typescript@5.2.2)
+    version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.4.5)
   '@typescript-eslint/parser':
     specifier: ^5.62.0
-    version: 5.62.0(eslint@8.53.0)(typescript@5.2.2)
+    version: 5.62.0(eslint@8.57.0)(typescript@5.4.5)
   benchmark:
     specifier: ^2.1.4
     version: 2.1.4
@@ -75,16 +75,16 @@ devDependencies:
     version: 1.2.2
   eslint:
     specifier: ^8.53.0
-    version: 8.53.0
+    version: 8.57.0
   eslint-plugin-jest:
     specifier: ^27.6.0
-    version: 27.6.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.53.0)(jest@29.7.0)(typescript@5.2.2)
+    version: 27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.5)
   find-root:
     specifier: ^1.1.0
     version: 1.1.0
   jest:
     specifier: ^29.7.0
-    version: 29.7.0(@types/node@18.18.9)(ts-node@10.9.1)
+    version: 29.7.0(@types/node@20.12.11)(ts-node@10.9.2)
   lodash:
     specifier: ^4.17.21
     version: 4.17.21
@@ -92,21 +92,16 @@ devDependencies:
     specifier: ^3.1.1
     version: 3.1.1
   prettier:
-    specifier: ^2.8.8
-    version: 2.8.8
+    specifier: ^3.2.5
+    version: 3.2.5
   ts-node:
-    specifier: ^10.9.1
-    version: 10.9.1(@swc/core@1.3.96)(@types/node@18.18.9)(typescript@5.2.2)
+    specifier: ^10.9.2
+    version: 10.9.2(@swc/core@1.5.5)(@types/node@20.12.11)(typescript@5.4.5)
   typescript:
-    specifier: ^5.2.2
-    version: 5.2.2
+    specifier: ^5.4.5
+    version: 5.4.5
 
 packages:
-
-  /@aashutoshrathi/word-wrap@1.2.6:
-    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -114,13 +109,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
-    dev: true
-
-  /@babel/code-frame@7.18.6:
-    resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': 7.18.6
     dev: true
 
   /@babel/code-frame@7.22.13:
@@ -245,11 +233,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-validator-identifier@7.19.1:
-    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
@@ -269,15 +252,6 @@ packages:
       '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@babel/highlight@7.18.6:
-    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
-      chalk: 2.4.2
-      js-tokens: 4.0.0
     dev: true
 
   /@babel/highlight@7.22.20:
@@ -466,22 +440,28 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@codspeed/benchmark.js-plugin@2.2.0(benchmark@2.1.4):
-    resolution: {integrity: sha512-tAnf4QGylkCLtIC/1olNcPEWoLokZ5/u8a5sNK1ry/jGSgxV4bfNqEEnzw3ncHklGhSdh7egVEgLdyjQftTZzQ==}
+  /@codspeed/benchmark.js-plugin@3.1.0(benchmark@2.1.4):
+    resolution: {integrity: sha512-PHF/QJ3WzTEX9nyhq6EHPA/pkHfMCW0FtfmJvl1qQSt0yIqpM4f0iBIfowua1AzbyD+Pd6iOPvlLHqO7ziLc+Q==}
     peerDependencies:
       benchmark: ^2.1.0
     dependencies:
-      '@codspeed/core': 2.2.0
+      '@codspeed/core': 3.1.0
       benchmark: 2.1.4
-      find-up: 6.3.0
       lodash: 4.17.21
       stack-trace: 1.0.0-pre2
+    transitivePeerDependencies:
+      - debug
     dev: true
 
-  /@codspeed/core@2.2.0:
-    resolution: {integrity: sha512-GSbTPA5Vt7rsrTenP/08zC55Ob2ag8AmqH9BfnoJqDv5RyHDv6tIHkJMLPuqatcKGFbuxbpE/FSYFE2xKkvqRQ==}
+  /@codspeed/core@3.1.0:
+    resolution: {integrity: sha512-oYd7X46QhnRkgRbZkqAoX9i3Fwm17FpunK4Ee5RdrvRYR0Xr93ewH8/O5g6uyTPDOOqDEv1v2KRYtWhVgN+2VQ==}
     dependencies:
-      node-gyp-build: 4.6.0
+      axios: 1.6.8
+      find-up: 6.3.0
+      form-data: 4.0.0
+      node-gyp-build: 4.8.1
+    transitivePeerDependencies:
+      - debug
     dev: true
 
   /@cspotcode/source-map-support@0.8.1:
@@ -500,23 +480,13 @@ packages:
       jsdoc-type-pratt-parser: 3.1.0
     dev: true
 
-  /@eslint-community/eslint-utils@4.3.0(eslint@8.53.0):
-    resolution: {integrity: sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 8.53.0
-      eslint-visitor-keys: 3.4.3
-    dev: true
-
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.53.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.57.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.53.0
+      eslint: 8.57.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -525,20 +495,15 @@ packages:
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
-  /@eslint-community/regexpp@4.4.0:
-    resolution: {integrity: sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: true
-
-  /@eslint/eslintrc@2.1.3:
-    resolution: {integrity: sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==}
+  /@eslint/eslintrc@2.1.4:
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 9.6.1
-      globals: 13.20.0
-      ignore: 5.2.4
+      globals: 13.24.0
+      ignore: 5.3.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -547,17 +512,17 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/js@8.53.0:
-    resolution: {integrity: sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==}
+  /@eslint/js@8.57.0:
+    resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@faker-js/faker@7.6.0:
-    resolution: {integrity: sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==}
-    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+  /@faker-js/faker@8.4.1:
+    resolution: {integrity: sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
     dev: true
 
-  /@gadgetinc/eslint-config@0.6.1(@gadgetinc/prettier-config@0.4.0)(eslint@8.53.0)(jest@29.7.0)(lodash@4.17.21)(typescript@5.2.2):
+  /@gadgetinc/eslint-config@0.6.1(@gadgetinc/prettier-config@0.4.0)(eslint@8.57.0)(jest@29.7.0)(lodash@4.17.21)(typescript@5.4.5):
     resolution: {integrity: sha512-RFxEUYbQS9feOikGDphXWdHTkMHtO3g8x6XYwo9FPRK1VuzRpRhsiU1QXA1yU+KEGW5kMNU02t/iCFLoXkdl3g==}
     peerDependencies:
       '@gadgetinc/prettier-config': '>=0'
@@ -565,22 +530,22 @@ packages:
       lodash: '>=4'
       typescript: '>=2.8.0'
     dependencies:
-      '@gadgetinc/prettier-config': 0.4.0(prettier@2.8.8)(typescript@5.2.2)
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.53.0)(typescript@5.2.2)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.53.0)(typescript@5.2.2)
-      eslint: 8.53.0
-      eslint-config-prettier: 8.8.0(eslint@8.53.0)
-      eslint-plugin-baseui: 10.12.1(eslint@8.53.0)
-      eslint-plugin-cypress: 2.12.1(eslint@8.53.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0)(eslint@8.53.0)
-      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.53.0)(jest@29.7.0)(typescript@5.2.2)
-      eslint-plugin-jsdoc: 39.9.1(eslint@8.53.0)
-      eslint-plugin-lodash: 7.4.0(eslint@8.53.0)
-      eslint-plugin-react: 7.32.2(eslint@8.53.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.53.0)
+      '@gadgetinc/prettier-config': 0.4.0(prettier@3.2.5)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+      eslint-config-prettier: 8.8.0(eslint@8.57.0)
+      eslint-plugin-baseui: 10.12.1(eslint@8.57.0)
+      eslint-plugin-cypress: 2.12.1(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)
+      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.5)
+      eslint-plugin-jsdoc: 39.9.1(eslint@8.57.0)
+      eslint-plugin-lodash: 7.4.0(eslint@8.57.0)
+      eslint-plugin-react: 7.32.2(eslint@8.57.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
       eslint-plugin-workspaces: 0.7.0
       lodash: 4.17.21
-      typescript: 5.2.2
+      typescript: 5.4.5
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -588,24 +553,24 @@ packages:
       - supports-color
     dev: true
 
-  /@gadgetinc/prettier-config@0.4.0(prettier@2.8.8)(typescript@5.2.2):
+  /@gadgetinc/prettier-config@0.4.0(prettier@3.2.5)(typescript@5.4.5):
     resolution: {integrity: sha512-a5jSbHlFjg3WojaDONSGPPvwJdToqpSAixHpLOJ55xMqnfOTRxY2Qr41lPDmLryfch0vD8v/Fnue3/pkwZKVdQ==}
     peerDependencies:
       prettier: ^2.8.1
     dependencies:
-      prettier: 2.8.8
-      prettier-plugin-organize-imports: 3.2.2(prettier@2.8.8)(typescript@5.2.2)
+      prettier: 3.2.5
+      prettier-plugin-organize-imports: 3.2.2(prettier@3.2.5)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@volar/vue-language-plugin-pug'
       - '@volar/vue-typescript'
       - typescript
     dev: true
 
-  /@humanwhocodes/config-array@0.11.13:
-    resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
+  /@humanwhocodes/config-array@0.11.14:
+    resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
     dependencies:
-      '@humanwhocodes/object-schema': 2.0.1
+      '@humanwhocodes/object-schema': 2.0.3
       debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
@@ -617,8 +582,8 @@ packages:
     engines: {node: '>=12.22'}
     dev: true
 
-  /@humanwhocodes/object-schema@2.0.1:
-    resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
+  /@humanwhocodes/object-schema@2.0.3:
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     dev: true
 
   /@istanbuljs/load-nyc-config@1.1.0:
@@ -642,14 +607,14 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
     dev: true
 
-  /@jest/core@29.7.0(ts-node@10.9.1):
+  /@jest/core@29.7.0(ts-node@10.9.2):
     resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -663,14 +628,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.18.9)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@20.12.11)(ts-node@10.9.2)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -692,11 +657,11 @@ packages:
       - ts-node
     dev: true
 
-  /@jest/create-cache-key-function@27.5.1:
-    resolution: {integrity: sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+  /@jest/create-cache-key-function@29.7.0:
+    resolution: {integrity: sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 27.5.1
+      '@jest/types': 29.6.3
     dev: true
 
   /@jest/environment@29.7.0:
@@ -705,15 +670,8 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       jest-mock: 29.7.0
-    dev: true
-
-  /@jest/expect-utils@29.5.0:
-    resolution: {integrity: sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      jest-get-type: 29.4.3
     dev: true
 
   /@jest/expect-utils@29.7.0:
@@ -739,7 +697,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -772,7 +730,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.20
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -792,13 +750,6 @@ packages:
       v8-to-istanbul: 9.1.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@jest/schemas@29.4.3:
-    resolution: {integrity: sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@sinclair/typebox': 0.25.24
     dev: true
 
   /@jest/schemas@29.6.3:
@@ -860,17 +811,6 @@ packages:
       - supports-color
     dev: true
 
-  /@jest/types@27.5.1:
-    resolution: {integrity: sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    dependencies:
-      '@types/istanbul-lib-coverage': 2.0.4
-      '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.18.9
-      '@types/yargs': 16.0.5
-      chalk: 4.1.2
-    dev: true
-
   /@jest/types@29.6.3:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -878,7 +818,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       '@types/yargs': 17.0.30
       chalk: 4.1.2
     dev: true
@@ -899,23 +839,19 @@ packages:
       '@jridgewell/trace-mapping': 0.3.20
     dev: true
 
-  /@jridgewell/resolve-uri@3.1.0:
-    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+  /@jridgewell/resolve-uri@3.1.1:
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
     engines: {node: '>=6.0.0'}
     dev: true
 
-  /@jridgewell/resolve-uri@3.1.1:
-    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+  /@jridgewell/resolve-uri@3.1.2:
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
     dev: true
 
   /@jridgewell/set-array@1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
-    dev: true
-
-  /@jridgewell/sourcemap-codec@1.4.14:
-    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
     dev: true
 
   /@jridgewell/sourcemap-codec@1.4.15:
@@ -932,8 +868,8 @@ packages:
   /@jridgewell/trace-mapping@0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /@nodelib/fs.scandir@2.1.5:
@@ -954,11 +890,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.15.0
-    dev: true
-
-  /@sinclair/typebox@0.25.24:
-    resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
+      fastq: 1.17.1
     dev: true
 
   /@sinclair/typebox@0.27.8:
@@ -977,8 +909,8 @@ packages:
       '@sinonjs/commons': 3.0.0
     dev: true
 
-  /@swc/core-darwin-arm64@1.3.96:
-    resolution: {integrity: sha512-8hzgXYVd85hfPh6mJ9yrG26rhgzCmcLO0h1TIl8U31hwmTbfZLzRitFQ/kqMJNbIBCwmNH1RU2QcJnL3d7f69A==}
+  /@swc/core-darwin-arm64@1.5.5:
+    resolution: {integrity: sha512-Ol5ZwZYdTOZsv2NwjcT/qVVALKzVFeh+IJ4GNarr3P99+38Dkwi81OqCI1o/WaDXQYKAQC/V+CzMbkEuJJfq9Q==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -986,8 +918,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-darwin-x64@1.3.96:
-    resolution: {integrity: sha512-mFp9GFfuPg+43vlAdQZl0WZpZSE8sEzqL7sr/7Reul5McUHP0BaLsEzwjvD035ESfkY8GBZdLpMinblIbFNljQ==}
+  /@swc/core-darwin-x64@1.5.5:
+    resolution: {integrity: sha512-XHWpKBIPKYLgh5/lV2PYjO84lkzf5JR51kjiloyz2Pa9HIV8tHoAP8bYdJwm4nUp2I7KcEh3pPH0AVu5LpxMKw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -995,8 +927,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm-gnueabihf@1.3.96:
-    resolution: {integrity: sha512-8UEKkYJP4c8YzYIY/LlbSo8z5Obj4hqcv/fUTHiEePiGsOddgGf7AWjh56u7IoN/0uEmEro59nc1ChFXqXSGyg==}
+  /@swc/core-linux-arm-gnueabihf@1.5.5:
+    resolution: {integrity: sha512-vtoWNCWAe+CNSqtqIwFnIH48qgPPlUZKoQ4EVFeMM+7/kDi6SeNxoh5TierJs5bKAWxD49VkPvRoWFCk6V62mA==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
@@ -1004,8 +936,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm64-gnu@1.3.96:
-    resolution: {integrity: sha512-c/IiJ0s1y3Ymm2BTpyC/xr6gOvoqAVETrivVXHq68xgNms95luSpbYQ28rqaZC8bQC8M5zdXpSc0T8DJu8RJGw==}
+  /@swc/core-linux-arm64-gnu@1.5.5:
+    resolution: {integrity: sha512-L4l7M78U6h/rCAxId+y5Vu+1KfDRF6dJZtitFcaT293guiUQFwJv8gLxI4Jh5wFtZ0fYd0QaCuvh2Ip79CzGMg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -1013,8 +945,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm64-musl@1.3.96:
-    resolution: {integrity: sha512-i5/UTUwmJLri7zhtF6SAo/4QDQJDH2fhYJaBIUhrICmIkRO/ltURmpejqxsM/ye9Jqv5zG7VszMC0v/GYn/7BQ==}
+  /@swc/core-linux-arm64-musl@1.5.5:
+    resolution: {integrity: sha512-DkzJc13ukXa7oJpyn24BjIgsiOybYrc+IxjsQyfNlDrrs1QXP4elStcpkD02SsIuSyHjZV8Hw2HFBMQB3OHPrA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -1022,8 +954,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-x64-gnu@1.3.96:
-    resolution: {integrity: sha512-USdaZu8lTIkm4Yf9cogct/j5eqtdZqTgcTib4I+NloUW0E/hySou3eSyp3V2UAA1qyuC72ld1otXuyKBna0YKQ==}
+  /@swc/core-linux-x64-gnu@1.5.5:
+    resolution: {integrity: sha512-kj4ZwWJGeBEUzHrRQP2VudN+kkkYH7OI1dPVDc6kWQx5X4329JeKOas4qY0l7gDVjBbRwN9IbbPI6TIn2KfAug==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -1031,8 +963,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-x64-musl@1.3.96:
-    resolution: {integrity: sha512-QYErutd+G2SNaCinUVobfL7jWWjGTI0QEoQ6hqTp7PxCJS/dmKmj3C5ZkvxRYcq7XcZt7ovrYCTwPTHzt6lZBg==}
+  /@swc/core-linux-x64-musl@1.5.5:
+    resolution: {integrity: sha512-6pTorCs4mYhPhYtC4jNOnhGgjNd3DZcRoZ9P0tzXXP69aCbYjvlgNH/NRvAROp9AaVFeZ7a7PmCWb6+Rbe7NKg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -1040,8 +972,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-arm64-msvc@1.3.96:
-    resolution: {integrity: sha512-hjGvvAduA3Un2cZ9iNP4xvTXOO4jL3G9iakhFsgVhpkU73SGmK7+LN8ZVBEu4oq2SUcHO6caWvnZ881cxGuSpg==}
+  /@swc/core-win32-arm64-msvc@1.5.5:
+    resolution: {integrity: sha512-o0/9pstmEjwZyrY/bA+mymF0zH7E+GT/XCVqdKeWW9Wn3gTTyWa5MZnrFgI2THQ+AXwdglMB/Zo76ARQPaz/+A==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -1049,8 +981,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-ia32-msvc@1.3.96:
-    resolution: {integrity: sha512-Far2hVFiwr+7VPCM2GxSmbh3ikTpM3pDombE+d69hkedvYHYZxtTF+2LTKl/sXtpbUnsoq7yV/32c9R/xaaWfw==}
+  /@swc/core-win32-ia32-msvc@1.5.5:
+    resolution: {integrity: sha512-B+nypUwsmCuaH6RtKWgiPCb+ENjxstJPPJeMJvBqlJqyCaIkZzN4M07Ozi3xVv1VG21SRkd6G3xIqRoalrNc0Q==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -1058,8 +990,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-x64-msvc@1.3.96:
-    resolution: {integrity: sha512-4VbSAniIu0ikLf5mBX81FsljnfqjoVGleEkCQv4+zRlyZtO3FHoDPkeLVoy6WRlj7tyrRcfUJ4mDdPkbfTO14g==}
+  /@swc/core-win32-x64-msvc@1.5.5:
+    resolution: {integrity: sha512-ry83ki9ZX0Q+GWGnqc2J618Z+FvKE8Ajn42F8EYi8Wj0q6Jz3mj+pJzgzakk2INm2ldEZ+FaRPipn4ozsZDcBg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -1067,8 +999,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core@1.3.96:
-    resolution: {integrity: sha512-zwE3TLgoZwJfQygdv2SdCK9mRLYluwDOM53I+dT6Z5ZvrgVENmY3txvWDvduzkV+/8IuvrRbVezMpxcojadRdQ==}
+  /@swc/core@1.5.5:
+    resolution: {integrity: sha512-M8O22EEgdSONLd+7KRrXj8pn+RdAZZ7ISnPjE9KCQQlI0kkFNEquWR+uFdlFxQfwlyCe/Zb6uGXGDvtcov4IMg==}
     engines: {node: '>=10'}
     requiresBuild: true
     peerDependencies:
@@ -1077,42 +1009,45 @@ packages:
       '@swc/helpers':
         optional: true
     dependencies:
-      '@swc/counter': 0.1.2
-      '@swc/types': 0.1.5
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.6
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.3.96
-      '@swc/core-darwin-x64': 1.3.96
-      '@swc/core-linux-arm-gnueabihf': 1.3.96
-      '@swc/core-linux-arm64-gnu': 1.3.96
-      '@swc/core-linux-arm64-musl': 1.3.96
-      '@swc/core-linux-x64-gnu': 1.3.96
-      '@swc/core-linux-x64-musl': 1.3.96
-      '@swc/core-win32-arm64-msvc': 1.3.96
-      '@swc/core-win32-ia32-msvc': 1.3.96
-      '@swc/core-win32-x64-msvc': 1.3.96
+      '@swc/core-darwin-arm64': 1.5.5
+      '@swc/core-darwin-x64': 1.5.5
+      '@swc/core-linux-arm-gnueabihf': 1.5.5
+      '@swc/core-linux-arm64-gnu': 1.5.5
+      '@swc/core-linux-arm64-musl': 1.5.5
+      '@swc/core-linux-x64-gnu': 1.5.5
+      '@swc/core-linux-x64-musl': 1.5.5
+      '@swc/core-win32-arm64-msvc': 1.5.5
+      '@swc/core-win32-ia32-msvc': 1.5.5
+      '@swc/core-win32-x64-msvc': 1.5.5
     dev: true
 
-  /@swc/counter@0.1.2:
-    resolution: {integrity: sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==}
+  /@swc/counter@0.1.3:
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
     dev: true
 
-  /@swc/jest@0.2.29(@swc/core@1.3.96):
-    resolution: {integrity: sha512-8reh5RvHBsSikDC3WGCd5ZTd2BXKkyOdK7QwynrCH58jk2cQFhhHhFBg/jvnWZehUQe/EoOImLENc9/DwbBFow==}
+  /@swc/jest@0.2.36(@swc/core@1.5.5):
+    resolution: {integrity: sha512-8X80dp81ugxs4a11z1ka43FPhP+/e+mJNXJSxiNYk8gIX/jPBtY4gQTrKu/KIoco8bzKuPI5lUxjfLiGsfvnlw==}
     engines: {npm: '>= 7.0.0'}
     peerDependencies:
       '@swc/core': '*'
     dependencies:
-      '@jest/create-cache-key-function': 27.5.1
-      '@swc/core': 1.3.96
-      jsonc-parser: 3.2.0
+      '@jest/create-cache-key-function': 29.7.0
+      '@swc/core': 1.5.5
+      '@swc/counter': 0.1.3
+      jsonc-parser: 3.2.1
     dev: true
 
-  /@swc/types@0.1.5:
-    resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
+  /@swc/types@0.1.6:
+    resolution: {integrity: sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==}
+    dependencies:
+      '@swc/counter': 0.1.3
     dev: true
 
-  /@tsconfig/node10@1.0.9:
-    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+  /@tsconfig/node10@1.0.11:
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
     dev: true
 
   /@tsconfig/node12@1.0.11:
@@ -1123,8 +1058,8 @@ packages:
     resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
     dev: true
 
-  /@tsconfig/node16@1.0.3:
-    resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
   /@types/babel__core@7.20.4:
@@ -1167,21 +1102,11 @@ packages:
   /@types/graceful-fs@4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
-      '@types/node': 18.18.9
-    dev: true
-
-  /@types/istanbul-lib-coverage@2.0.4:
-    resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
+      '@types/node': 20.12.11
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.6:
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
-    dev: true
-
-  /@types/istanbul-lib-report@3.0.0:
-    resolution: {integrity: sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==}
-    dependencies:
-      '@types/istanbul-lib-coverage': 2.0.4
     dev: true
 
   /@types/istanbul-lib-report@3.0.3:
@@ -1190,27 +1115,17 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.6
     dev: true
 
-  /@types/istanbul-reports@3.0.1:
-    resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
-    dependencies:
-      '@types/istanbul-lib-report': 3.0.0
-    dev: true
-
   /@types/istanbul-reports@3.0.4:
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
     dev: true
 
-  /@types/jest@29.5.8:
-    resolution: {integrity: sha512-fXEFTxMV2Co8ZF5aYFJv+YeA08RTYJfhtN5c9JSv/mFEMe+xxjufCb+PHL+bJcMs/ebPUsBu+UNTEz+ydXrR6g==}
+  /@types/jest@29.5.12:
+    resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
     dependencies:
-      expect: 29.5.0
-      pretty-format: 29.5.0
-    dev: true
-
-  /@types/json-schema@7.0.11:
-    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
+      expect: 29.7.0
+      pretty-format: 29.7.0
     dev: true
 
   /@types/json-schema@7.0.15:
@@ -1231,40 +1146,22 @@ packages:
     resolution: {integrity: sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==}
     dev: true
 
-  /@types/node@18.18.9:
-    resolution: {integrity: sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==}
+  /@types/node@20.12.11:
+    resolution: {integrity: sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==}
     dependencies:
       undici-types: 5.26.5
     dev: true
 
-  /@types/semver@7.3.13:
-    resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
-    dev: true
-
-  /@types/semver@7.5.4:
-    resolution: {integrity: sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==}
-    dev: true
-
-  /@types/stack-utils@2.0.1:
-    resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+  /@types/semver@7.5.8:
+    resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
     dev: true
 
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
     dev: true
 
-  /@types/yargs-parser@21.0.0:
-    resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
-    dev: true
-
   /@types/yargs-parser@21.0.2:
     resolution: {integrity: sha512-5qcvofLPbfjmBfKaLfj/+f+Sbd6pN4zl7w7VSVI5uz7m9QZTuB2aZAa2uo1wHFBNN2x6g/SoTkXmd8mQnQF2Cw==}
-    dev: true
-
-  /@types/yargs@16.0.5:
-    resolution: {integrity: sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==}
-    dependencies:
-      '@types/yargs-parser': 21.0.0
     dev: true
 
   /@types/yargs@17.0.30:
@@ -1273,7 +1170,7 @@ packages:
       '@types/yargs-parser': 21.0.2
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.53.0)(typescript@5.2.2):
+  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.4.5):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1284,24 +1181,24 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.4.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.53.0)(typescript@5.2.2)
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.53.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.53.0)(typescript@5.2.2)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       debug: 4.3.4
-      eslint: 8.53.0
+      eslint: 8.57.0
       graphemer: 1.4.0
-      ignore: 5.2.4
+      ignore: 5.3.1
       natural-compare-lite: 1.4.0
-      semver: 7.3.8
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      semver: 7.6.1
+      tsutils: 3.21.0(typescript@5.4.5)
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.53.0)(typescript@5.2.2):
+  /@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1313,20 +1210,12 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
       debug: 4.3.4
-      eslint: 8.53.0
-      typescript: 5.2.2
+      eslint: 8.57.0
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@typescript-eslint/scope-manager@5.56.0:
-    resolution: {integrity: sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.56.0
-      '@typescript-eslint/visitor-keys': 5.56.0
     dev: true
 
   /@typescript-eslint/scope-manager@5.62.0:
@@ -1337,7 +1226,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: true
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.53.0)(typescript@5.2.2):
+  /@typescript-eslint/type-utils@5.62.0(eslint@8.57.0)(typescript@5.4.5):
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1347,19 +1236,14 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.53.0)(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       debug: 4.3.4
-      eslint: 8.53.0
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      eslint: 8.57.0
+      tsutils: 3.21.0(typescript@5.4.5)
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@typescript-eslint/types@5.56.0:
-    resolution: {integrity: sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
   /@typescript-eslint/types@5.62.0:
@@ -1367,28 +1251,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.56.0(typescript@5.2.2):
-    resolution: {integrity: sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.56.0
-      '@typescript-eslint/visitor-keys': 5.56.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.8
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.2.2):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.4.5):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1402,59 +1265,31 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      semver: 7.6.1
+      tsutils: 3.21.0(typescript@5.4.5)
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.56.0(eslint@8.53.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.3.0(eslint@8.53.0)
-      '@types/json-schema': 7.0.11
-      '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.56.0
-      '@typescript-eslint/types': 5.56.0
-      '@typescript-eslint/typescript-estree': 5.56.0(typescript@5.2.2)
-      eslint: 8.53.0
-      eslint-scope: 5.1.1
-      semver: 7.3.8
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/utils@5.62.0(eslint@8.53.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.4.5):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.53.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.4
+      '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
-      eslint: 8.53.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
+      eslint: 8.57.0
       eslint-scope: 5.1.1
-      semver: 7.3.8
+      semver: 7.6.1
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
-
-  /@typescript-eslint/visitor-keys@5.56.0:
-    resolution: {integrity: sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.56.0
-      eslint-visitor-keys: 3.4.3
     dev: true
 
   /@typescript-eslint/visitor-keys@5.62.0:
@@ -1469,27 +1304,21 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
-  /acorn-jsx@5.3.2(acorn@8.11.2):
+  /acorn-jsx@5.3.2(acorn@8.11.3):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.11.2
+      acorn: 8.11.3
     dev: true
 
-  /acorn-walk@8.2.0:
-    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
     dev: true
 
-  /acorn@8.11.2:
-    resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-    dev: true
-
-  /acorn@8.8.2:
-    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
+  /acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -1625,9 +1454,23 @@ packages:
       get-intrinsic: 1.2.0
     dev: true
 
+  /asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: true
+
   /available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
+    dev: true
+
+  /axios@1.6.8:
+    resolution: {integrity: sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==}
+    dependencies:
+      follow-redirects: 1.15.6
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
     dev: true
 
   /babel-jest@29.7.0(@babel/core@7.23.2):
@@ -1796,11 +1639,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /ci-info@3.8.0:
-    resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
-    engines: {node: '>=8'}
-    dev: true
-
   /ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -1849,6 +1687,13 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
+  /combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: true
+
   /comment-parser@1.3.1:
     resolution: {integrity: sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==}
     engines: {node: '>= 12.0.0'}
@@ -1870,7 +1715,7 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
 
-  /create-jest@29.7.0(@types/node@18.18.9)(ts-node@10.9.1):
+  /create-jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.2):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -1879,7 +1724,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.18.9)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@20.12.11)(ts-node@10.9.2)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -1955,6 +1800,11 @@ packages:
       object-keys: 1.1.1
     dev: true
 
+  /delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
   /deoptigate@0.7.1:
     resolution: {integrity: sha512-nXPV1DOU3DHUzpD2109mD507m3QczL/LQmpZ1QVRf6GdS092zyGalxgbxQGOs/hAJxKPPttIrxh7tPCDMV4cJA==}
     hasBin: true
@@ -1979,11 +1829,6 @@ packages:
     dependencies:
       semver: 7.5.4
       winreg: 1.2.5
-    dev: true
-
-  /diff-sequences@29.4.3:
-    resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /diff-sequences@29.6.3:
@@ -2133,13 +1978,13 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-prettier@8.8.0(eslint@8.53.0):
+  /eslint-config-prettier@8.8.0(eslint@8.57.0):
     resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 8.53.0
+      eslint: 8.57.0
     dev: true
 
   /eslint-import-resolver-node@0.3.7:
@@ -2152,7 +1997,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint@8.53.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint@8.57.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2173,33 +2018,33 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.53.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       debug: 3.2.7
-      eslint: 8.53.0
+      eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-baseui@10.12.1(eslint@8.53.0):
+  /eslint-plugin-baseui@10.12.1(eslint@8.57.0):
     resolution: {integrity: sha512-sYeXdYvmk13IkgLQWr2MaD4QGXZNbetftsu+SAlV8BIGVVTjsRipZ8XYNot2wIjThjU0mEPbshUPDhtQSqtxrQ==}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.53.0
+      eslint: 8.57.0
       jsx-ast-utils: 3.3.3
     dev: true
 
-  /eslint-plugin-cypress@2.12.1(eslint@8.53.0):
+  /eslint-plugin-cypress@2.12.1(eslint@8.57.0):
     resolution: {integrity: sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==}
     peerDependencies:
       eslint: '>= 3.2.1'
     dependencies:
-      eslint: 8.53.0
+      eslint: 8.57.0
       globals: 11.12.0
     dev: true
 
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0)(eslint@8.53.0):
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0)(eslint@8.57.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2209,15 +2054,15 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.53.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.53.0
+      eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint@8.53.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint@8.57.0)
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -2232,7 +2077,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.53.0)(jest@29.7.0)(typescript@5.2.2):
+  /eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.5):
     resolution: {integrity: sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2245,20 +2090,20 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.53.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.53.0)(typescript@5.2.2)
-      eslint: 8.53.0
-      jest: 29.7.0(@types/node@18.18.9)(ts-node@10.9.1)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+      jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jest@27.6.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.53.0)(jest@29.7.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-MTlusnnDMChbElsszJvrwD1dN3x6nZl//s4JD23BxB6MgR66TZlL064su24xEIS3VACfAoHV1vgyMgPw8nkdng==}
+  /eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.0.0 || ^6.0.0
+      '@typescript-eslint/eslint-plugin': ^5.0.0 || ^6.0.0 || ^7.0.0
       eslint: ^7.0.0 || ^8.0.0
       jest: '*'
     peerDependenciesMeta:
@@ -2267,16 +2112,16 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.53.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.56.0(eslint@8.53.0)(typescript@5.2.2)
-      eslint: 8.53.0
-      jest: 29.7.0(@types/node@18.18.9)(ts-node@10.9.1)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+      jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jsdoc@39.9.1(eslint@8.53.0):
+  /eslint-plugin-jsdoc@39.9.1(eslint@8.57.0):
     resolution: {integrity: sha512-Rq2QY6BZP2meNIs48aZ3GlIlJgBqFCmR55+UBvaDkA3ZNQ0SvQXOs2QKkubakEijV8UbIVbVZKsOVN8G3MuqZw==}
     engines: {node: ^14 || ^16 || ^17 || ^18 || ^19}
     peerDependencies:
@@ -2286,34 +2131,34 @@ packages:
       comment-parser: 1.3.1
       debug: 4.3.4
       escape-string-regexp: 4.0.0
-      eslint: 8.53.0
+      eslint: 8.57.0
       esquery: 1.5.0
-      semver: 7.5.4
+      semver: 7.6.1
       spdx-expression-parse: 3.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-lodash@7.4.0(eslint@8.53.0):
+  /eslint-plugin-lodash@7.4.0(eslint@8.57.0):
     resolution: {integrity: sha512-Tl83UwVXqe1OVeBRKUeWcfg6/pCW1GTRObbdnbEJgYwjxp5Q92MEWQaH9+dmzbRt6kvYU1Mp893E79nJiCSM8A==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: '>=2'
     dependencies:
-      eslint: 8.53.0
+      eslint: 8.57.0
       lodash: 4.17.21
     dev: true
 
-  /eslint-plugin-react-hooks@4.6.0(eslint@8.53.0):
+  /eslint-plugin-react-hooks@4.6.0(eslint@8.57.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 8.53.0
+      eslint: 8.57.0
     dev: true
 
-  /eslint-plugin-react@7.32.2(eslint@8.53.0):
+  /eslint-plugin-react@7.32.2(eslint@8.57.0):
     resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2323,7 +2168,7 @@ packages:
       array.prototype.flatmap: 1.3.1
       array.prototype.tosorted: 1.1.1
       doctrine: 2.1.0
-      eslint: 8.53.0
+      eslint: 8.57.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.3
       minimatch: 3.1.2
@@ -2365,16 +2210,16 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint@8.53.0:
-    resolution: {integrity: sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==}
+  /eslint@8.57.0:
+    resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.3.0(eslint@8.53.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@eslint-community/regexpp': 4.10.0
-      '@eslint/eslintrc': 2.1.3
-      '@eslint/js': 8.53.0
-      '@humanwhocodes/config-array': 0.11.13
+      '@eslint/eslintrc': 2.1.4
+      '@eslint/js': 8.57.0
+      '@humanwhocodes/config-array': 0.11.14
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.2.0
@@ -2393,9 +2238,9 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.20.0
+      globals: 13.24.0
       graphemer: 1.4.0
-      ignore: 5.2.4
+      ignore: 5.3.1
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
@@ -2405,7 +2250,7 @@ packages:
       lodash.merge: 4.6.2
       minimatch: 3.1.2
       natural-compare: 1.4.0
-      optionator: 0.9.3
+      optionator: 0.9.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
     transitivePeerDependencies:
@@ -2416,8 +2261,8 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.11.2
-      acorn-jsx: 5.3.2(acorn@8.11.2)
+      acorn: 8.11.3
+      acorn-jsx: 5.3.2(acorn@8.11.3)
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -2476,17 +2321,6 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /expect@29.5.0:
-    resolution: {integrity: sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/expect-utils': 29.5.0
-      jest-get-type: 29.4.3
-      jest-matcher-utils: 29.5.0
-      jest-message-util: 29.5.0
-      jest-util: 29.5.0
-    dev: true
-
   /expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2521,8 +2355,8 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
-  /fastq@1.15.0:
-    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
+  /fastq@1.17.1:
+    resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
     dependencies:
       reusify: 1.0.4
     dev: true
@@ -2537,7 +2371,7 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
-      flat-cache: 3.0.4
+      flat-cache: 3.2.0
     dev: true
 
   /files-provider@0.2.0:
@@ -2581,22 +2415,42 @@ packages:
       path-exists: 5.0.0
     dev: true
 
-  /flat-cache@3.0.4:
-    resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
+  /flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
-      flatted: 3.2.7
+      flatted: 3.3.1
+      keyv: 4.5.4
       rimraf: 3.0.2
     dev: true
 
-  /flatted@3.2.7:
-    resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
+  /flatted@3.3.1:
+    resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
+    dev: true
+
+  /follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
     dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
       is-callable: 1.2.7
+    dev: true
+
+  /form-data@4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
     dev: true
 
   /fs.realpath@1.0.0:
@@ -2699,8 +2553,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /globals@13.20.0:
-    resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
+  /globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -2720,7 +2574,7 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.2.4
+      ignore: 5.3.1
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -2815,8 +2669,8 @@ packages:
     resolution: {integrity: sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==}
     dev: true
 
-  /ignore@5.2.4:
-    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
+  /ignore@5.3.1:
+    resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
     dev: true
 
@@ -3054,7 +2908,7 @@ packages:
       '@babel/parser': 7.23.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.1
-      semver: 7.5.4
+      semver: 7.6.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3104,7 +2958,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -3125,7 +2979,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.7.0(@types/node@18.18.9)(ts-node@10.9.1):
+  /jest-cli@29.7.0(@types/node@20.12.11)(ts-node@10.9.2):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -3135,14 +2989,14 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1)
+      '@jest/core': 29.7.0(ts-node@10.9.2)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.18.9)(ts-node@10.9.1)
+      create-jest: 29.7.0(@types/node@20.12.11)(ts-node@10.9.2)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.18.9)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@20.12.11)(ts-node@10.9.2)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -3153,7 +3007,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.7.0(@types/node@18.18.9)(ts-node@10.9.1):
+  /jest-config@29.7.0(@types/node@20.12.11)(ts-node@10.9.2):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -3168,7 +3022,7 @@ packages:
       '@babel/core': 7.23.2
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       babel-jest: 29.7.0(@babel/core@7.23.2)
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -3188,20 +3042,10 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.3.96)(@types/node@18.18.9)(typescript@5.2.2)
+      ts-node: 10.9.2(@swc/core@1.5.5)(@types/node@20.12.11)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
-    dev: true
-
-  /jest-diff@29.5.0:
-    resolution: {integrity: sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      chalk: 4.1.2
-      diff-sequences: 29.4.3
-      jest-get-type: 29.4.3
-      pretty-format: 29.5.0
     dev: true
 
   /jest-diff@29.7.0:
@@ -3239,14 +3083,9 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       jest-mock: 29.7.0
       jest-util: 29.7.0
-    dev: true
-
-  /jest-get-type@29.4.3:
-    resolution: {integrity: sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /jest-get-type@29.6.3:
@@ -3260,7 +3099,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -3281,16 +3120,6 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /jest-matcher-utils@29.5.0:
-    resolution: {integrity: sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      chalk: 4.1.2
-      jest-diff: 29.5.0
-      jest-get-type: 29.4.3
-      pretty-format: 29.5.0
-    dev: true
-
   /jest-matcher-utils@29.7.0:
     resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3299,21 +3128,6 @@ packages:
       jest-diff: 29.7.0
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
-    dev: true
-
-  /jest-message-util@29.5.0:
-    resolution: {integrity: sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@jest/types': 29.6.3
-      '@types/stack-utils': 2.0.1
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      micromatch: 4.0.5
-      pretty-format: 29.5.0
-      slash: 3.0.0
-      stack-utils: 2.0.6
     dev: true
 
   /jest-message-util@29.7.0:
@@ -3336,7 +3150,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       jest-util: 29.7.0
     dev: true
 
@@ -3391,7 +3205,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -3422,7 +3236,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       chalk: 4.1.2
       cjs-module-lexer: 1.2.3
       collect-v8-coverage: 1.0.2
@@ -3464,21 +3278,9 @@ packages:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.5.4
+      semver: 7.6.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /jest-util@29.5.0:
-    resolution: {integrity: sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/types': 29.6.3
-      '@types/node': 18.18.9
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      graceful-fs: 4.2.11
-      picomatch: 2.3.1
     dev: true
 
   /jest-util@29.7.0:
@@ -3486,7 +3288,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -3511,7 +3313,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -3523,13 +3325,13 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 18.18.9
+      '@types/node': 20.12.11
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.7.0(@types/node@18.18.9)(ts-node@10.9.1):
+  /jest@29.7.0(@types/node@20.12.11)(ts-node@10.9.2):
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -3539,10 +3341,10 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1)
+      '@jest/core': 29.7.0(ts-node@10.9.2)
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.18.9)(ts-node@10.9.1)
+      jest-cli: 29.7.0(@types/node@20.12.11)(ts-node@10.9.2)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -3580,6 +3382,10 @@ packages:
     hasBin: true
     dev: true
 
+  /json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: true
+
   /json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
     dev: true
@@ -3609,8 +3415,8 @@ packages:
     hasBin: true
     dev: true
 
-  /jsonc-parser@3.2.0:
-    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+  /jsonc-parser@3.2.1:
+    resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
     dev: true
 
   /jsx-ast-utils@3.3.3:
@@ -3619,6 +3425,12 @@ packages:
     dependencies:
       array-includes: 3.1.6
       object.assign: 4.1.4
+    dev: true
+
+  /keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+    dependencies:
+      json-buffer: 3.0.1
     dev: true
 
   /kleur@3.0.3:
@@ -3710,7 +3522,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.1
     dev: true
 
   /make-error@1.3.6:
@@ -3749,6 +3561,18 @@ packages:
       node-gyp-build: 4.6.0
     dev: true
 
+  /mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: true
+
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -3771,16 +3595,16 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /mobx-state-tree@5.3.0(mobx@6.8.0):
-    resolution: {integrity: sha512-2XInCjIxGQx/UmTbpAreWKcHswmuOKOV23HJmy1x4gqyDqCcOHJcaClpWnD2/qQlGncg8gAUfP/mm+cLpTrtlQ==}
+  /mobx-state-tree@6.0.0(mobx@6.12.3):
+    resolution: {integrity: sha512-Aky3I5SMM1gKvI780TyxqSf+VDRpu03QONxqGerXG7DOemK3z1Ka2KfbPuiXm/znawsYDwqeZgmz0rjbCLSD8g==}
     peerDependencies:
       mobx: ^6.3.0
     dependencies:
-      mobx: 6.8.0
+      mobx: 6.12.3
     dev: false
 
-  /mobx@6.8.0:
-    resolution: {integrity: sha512-+o/DrHa4zykFMSKfS8Z+CPSEg5LW9tSNGTuN8o6MF1GKxlfkSHSeJn5UtgxvPkGgaouplnrLXCF+duAsmm6FHQ==}
+  /mobx@6.12.3:
+    resolution: {integrity: sha512-c8NKkO4R2lShkSXZ2Ongj1ycjugjzFFo/UswHBnS62y07DMcTc9Rvo03/3nRyszIvwPNljlkd4S828zIBv/piw==}
     dev: false
 
   /ms@2.1.2:
@@ -3809,6 +3633,11 @@ packages:
 
   /node-gyp-build@4.6.0:
     resolution: {integrity: sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==}
+    hasBin: true
+    dev: true
+
+  /node-gyp-build@4.8.1:
+    resolution: {integrity: sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==}
     hasBin: true
     dev: true
 
@@ -3910,16 +3739,16 @@ packages:
       is-wsl: 1.1.0
     dev: true
 
-  /optionator@0.9.3:
-    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
+  /optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
     dependencies:
-      '@aashutoshrathi/word-wrap': 1.2.6
       deep-is: 0.1.4
       fast-levenshtein: 2.0.6
       levn: 0.4.1
       prelude-ls: 1.2.1
       type-check: 0.4.0
+      word-wrap: 1.2.5
     dev: true
 
   /p-limit@2.3.0:
@@ -4065,7 +3894,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-organize-imports@3.2.2(prettier@2.8.8)(typescript@5.2.2):
+  /prettier-plugin-organize-imports@3.2.2(prettier@3.2.5)(typescript@5.4.5):
     resolution: {integrity: sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==}
     peerDependencies:
       '@volar/vue-language-plugin-pug': ^1.0.4
@@ -4078,23 +3907,14 @@ packages:
       '@volar/vue-typescript':
         optional: true
     dependencies:
-      prettier: 2.8.8
-      typescript: 5.2.2
+      prettier: 3.2.5
+      typescript: 5.4.5
     dev: true
 
-  /prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+  /prettier@3.2.5:
+    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
+    engines: {node: '>=14'}
     hasBin: true
-    dev: true
-
-  /pretty-format@29.5.0:
-    resolution: {integrity: sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/schemas': 29.4.3
-      ansi-styles: 5.2.0
-      react-is: 18.2.0
     dev: true
 
   /pretty-format@29.7.0:
@@ -4133,6 +3953,10 @@ packages:
       react-is: 16.13.1
     dev: true
 
+  /proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: true
+
   /pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
     dependencies:
@@ -4140,8 +3964,8 @@ packages:
       once: 1.4.0
     dev: true
 
-  /punycode@2.3.0:
-    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
+  /punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
     dev: true
 
@@ -4180,8 +4004,8 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /reflect-metadata@0.1.13:
-    resolution: {integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==}
+  /reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
     dev: false
 
   /regexp.prototype.flags@1.4.3:
@@ -4296,6 +4120,12 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
+
+  /semver@7.6.1:
+    resolution: {integrity: sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==}
+    engines: {node: '>=10'}
+    hasBin: true
     dev: true
 
   /shebang-command@2.0.0:
@@ -4539,8 +4369,8 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /ts-node@10.9.1(@swc/core@1.3.96)(@types/node@18.18.9)(typescript@5.2.2):
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+  /ts-node@10.9.2(@swc/core@1.5.5)(@types/node@20.12.11)(typescript@5.4.5):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
       '@swc/core': '>=1.2.50'
@@ -4554,19 +4384,19 @@ packages:
         optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.3.96
-      '@tsconfig/node10': 1.0.9
+      '@swc/core': 1.5.5
+      '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 18.18.9
-      acorn: 8.8.2
-      acorn-walk: 8.2.0
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.12.11
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.2.2
+      typescript: 5.4.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -4584,14 +4414,14 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tsutils@3.21.0(typescript@5.2.2):
+  /tsutils@3.21.0(typescript@5.4.5):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.2.2
+      typescript: 5.4.5
     dev: true
 
   /type-check@0.4.0:
@@ -4624,8 +4454,8 @@ packages:
       is-typed-array: 1.1.10
     dev: true
 
-  /typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+  /typescript@5.4.5:
+    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -4657,7 +4487,7 @@ packages:
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
-      punycode: 2.3.0
+      punycode: 2.3.1
     dev: true
 
   /util-deprecate@1.0.2:
@@ -4719,6 +4549,11 @@ packages:
 
   /winreg@1.2.5:
     resolution: {integrity: sha512-uf7tHf+tw0B1y+x+mKTLHkykBgK2KMs3g+KlzmyMbLvICSHQyB/xOFjTT8qZ3oeTFyU7Bbj4FzXitGG6jvKhYw==}
+    dev: true
+
+  /word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /wrap-ansi@7.0.0:

--- a/spec/api.spec.ts
+++ b/spec/api.spec.ts
@@ -154,7 +154,7 @@ describe("applySnapshot", () => {
     expect(instance).toEqual(
       expect.objectContaining({
         optional: "a different value",
-      })
+      }),
     );
   });
 
@@ -170,7 +170,7 @@ describe("applySnapshot", () => {
     expect(instance).toEqual(
       expect.objectContaining({
         optional: "a different value",
-      })
+      }),
     );
   });
 

--- a/spec/class-model-mixins.spec.ts
+++ b/spec/class-model-mixins.spec.ts
@@ -99,9 +99,9 @@ class ChainedA extends AddVolatileMixin(
     AddActionMixin(
       ClassModel({
         name: types.string,
-      })
-    )
-  )
+      }),
+    ),
+  ),
 ) {}
 
 @register
@@ -110,9 +110,9 @@ class ChainedB extends AddActionMixin(
     AddVolatileMixin(
       ClassModel({
         name: types.string,
-      })
-    )
-  )
+      }),
+    ),
+  ),
 ) {}
 
 @register
@@ -121,9 +121,9 @@ class ChainedC extends AddActionMixin(
     AddViewMixin(
       ClassModel({
         name: types.string,
-      })
-    )
-  )
+      }),
+    ),
+  ),
 ) {}
 
 describe("class model mixins", () => {

--- a/spec/class-model-references.spec.ts
+++ b/spec/class-model-references.spec.ts
@@ -50,14 +50,14 @@ describe("clas model references", () => {
           { key: "item-b", count: 523 },
         ],
       },
-      true
+      true,
     );
 
     expect(root.model.ref).toEqual(
       expect.objectContaining({
         key: "item-a",
         count: 12,
-      })
+      }),
     );
   });
 
@@ -74,7 +74,7 @@ describe("clas model references", () => {
             { key: "item-b", count: 523 },
           ],
         },
-        true
+        true,
       );
 
     expect(createRoot).toThrow();
@@ -93,14 +93,14 @@ describe("clas model references", () => {
           { key: "item-b", count: 523 },
         ],
       },
-      true
+      true,
     );
 
     expect(root.model.safeRef).toEqual(
       expect.objectContaining({
         key: "item-b",
         count: 523,
-      })
+      }),
     );
   });
 
@@ -117,7 +117,7 @@ describe("clas model references", () => {
           { key: "item-b", count: 523 },
         ],
       },
-      true
+      true,
     );
 
     expect(root.model.safeRef).toBeUndefined();
@@ -136,7 +136,7 @@ describe("clas model references", () => {
           { key: "item-b", count: 523 },
         ],
       },
-      true
+      true,
     );
 
     expect(root.model.ref).toBe(root.refs[0]);
@@ -157,7 +157,7 @@ describe("clas model references", () => {
           { key: "item-b", count: 523 },
         ],
       },
-      true
+      true,
     );
 
     expect(root.model.safeRef).toBe(root.refs[1]);
@@ -172,9 +172,9 @@ describe("class model factories with generic references", () => {
     InstanceOfT extends StateTreeNode<InstanceWithoutSTNTypeForType<T>, IReferenceType<T>> = StateTreeNode<
       InstanceWithoutSTNTypeForType<T>,
       IReferenceType<T>
-    >
+    >,
   >(
-    type: T
+    type: T,
   ) => {
     return register(
       class extends ClassModel({
@@ -188,7 +188,7 @@ describe("class model factories with generic references", () => {
           this.someGenericReference = ref;
         }
       },
-      { setReference: action }
+      { setReference: action },
     );
   };
 
@@ -211,7 +211,7 @@ describe("class model factories with generic references", () => {
           { key: "item-b", count: 523 },
         ],
       },
-      false
+      false,
     );
 
     const instance = root.example;

--- a/spec/class-model.spec.ts
+++ b/spec/class-model.spec.ts
@@ -60,7 +60,7 @@ const DynamicNameExample = register(
     setVolatileProp: action,
     setVolatilePropOnReadonly: volatileAction,
   },
-  "NameExample"
+  "NameExample",
 );
 
 /**
@@ -283,7 +283,7 @@ describe("class models", () => {
                 name: "hello",
               },
             },
-            readOnly
+            readOnly,
           );
 
           expect(instance.key).toEqual("1");
@@ -394,7 +394,7 @@ describe("class models", () => {
 
       test("running async actions should throw because the instance is readonly", async () => {
         await expect(async () => await record.setNameAsync("Test 2")).rejects.toThrowErrorMatchingInlineSnapshot(
-          `"Can't run flow action for a readonly instance"`
+          `"Can't run flow action for a readonly instance"`,
         );
       });
 

--- a/spec/late.spec.ts
+++ b/spec/late.spec.ts
@@ -81,7 +81,7 @@ describe("late", () => {
               },
             ],
           },
-          observable
+          observable,
         );
 
         expect(basket.fruits.length).toBe(3);
@@ -98,7 +98,7 @@ describe("late", () => {
           {
             fruits: [apple, banana],
           },
-          observable
+          observable,
         );
 
         expect(basket.fruits.length).toBe(2);

--- a/spec/map.spec.ts
+++ b/spec/map.spec.ts
@@ -18,7 +18,7 @@ test("is can create a map of frozen types from a snapshot", () => {
     expect.objectContaining({
       A: "one",
       B: null,
-    })
+    }),
   );
 });
 
@@ -30,7 +30,7 @@ test("can create a map of complex types", () => {
     expect.objectContaining({
       A: expect.objectContaining({ name: "A", amount: 10 }),
       B: expect.objectContaining({ name: "B", amount: 0 }),
-    })
+    }),
   );
 });
 

--- a/spec/reference.spec.ts
+++ b/spec/reference.spec.ts
@@ -46,7 +46,7 @@ test("can resolve valid references", () => {
     expect.objectContaining({
       key: "item-a",
       count: 12,
-    })
+    }),
   );
 });
 
@@ -81,7 +81,7 @@ test("can resolve valid safe references", () => {
     expect.objectContaining({
       key: "item-b",
       count: 523,
-    })
+    }),
   );
 });
 

--- a/spec/schemaHash.spec.ts
+++ b/spec/schemaHash.spec.ts
@@ -14,10 +14,10 @@ describe("schemaHash", () => {
 
   test("is the same for enums with the same options", async () => {
     expect(await types.enumeration("whatever", ["foo", "bar"]).schemaHash()).toEqual(
-      await types.enumeration("other", ["foo", "bar"]).schemaHash()
+      await types.enumeration("other", ["foo", "bar"]).schemaHash(),
     );
     expect(await types.enumeration("whatever", ["foo", "bar"]).schemaHash()).not.toEqual(
-      await types.enumeration("other", ["foo", "bar", "baz"]).schemaHash()
+      await types.enumeration("other", ["foo", "bar", "baz"]).schemaHash(),
     );
   });
 
@@ -33,10 +33,10 @@ describe("schemaHash", () => {
 
   test("is the same for refinements of a same type", async () => {
     expect(await types.refinement(types.number, () => true).schemaHash()).toEqual(
-      await types.refinement(types.number, () => true).schemaHash()
+      await types.refinement(types.number, () => true).schemaHash(),
     );
     expect(await types.refinement(types.number, () => true).schemaHash()).not.toEqual(
-      await types.refinement(types.string, () => true).schemaHash()
+      await types.refinement(types.string, () => true).schemaHash(),
     );
   });
 
@@ -243,14 +243,14 @@ describe("schemaHash", () => {
         class extends ClassModel({
           foo: types.string,
           bar: types.number,
-        }) {}
+        }) {},
       );
 
       const b = register(
         class extends ClassModel({
           foo: types.string,
           bar: types.number,
-        }) {}
+        }) {},
       );
 
       expect(await a.schemaHash()).toEqual(await b.schemaHash());
@@ -266,14 +266,14 @@ describe("schemaHash", () => {
         class extends ClassModel({
           foo: types.string,
           bar: SubModel,
-        }) {}
+        }) {},
       );
 
       const b = register(
         class extends ClassModel({
           foo: types.string,
           bar: SubModel,
-        }) {}
+        }) {},
       );
 
       expect(await a.schemaHash()).toEqual(await b.schemaHash());

--- a/spec/union.spec.ts
+++ b/spec/union.spec.ts
@@ -39,7 +39,7 @@ describe("union", () => {
       expect(getSnapshot(unionInstance)).toEqual(
         expect.objectContaining({
           x: "test",
-        })
+        }),
       );
     });
 
@@ -70,7 +70,7 @@ describe("union", () => {
             },
           },
           Apple,
-          Banana
+          Banana,
         );
 
         const appleInstance = create(Union, { color: "red" }, readonly);
@@ -152,7 +152,7 @@ describe("union", () => {
     const Union = types.union({ discriminator: "type" }, Apple, Banana);
 
     expect(() => create(Union, { type: "pear" } as any, true)).toThrowErrorMatchingInlineSnapshot(
-      `"Discriminator property value \`pear\` for property \`type\` on incoming snapshot didn't correspond to a type. Options: apple, banana. Snapshot was \`{"type":"pear"}\`"`
+      `"Discriminator property value \`pear\` for property \`type\` on incoming snapshot didn't correspond to a type. Options: apple, banana. Snapshot was \`{"type":"pear"}\`"`,
     );
   });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,6 +13,7 @@ import {
   getParentOfType as mstGetParentOfType,
   getRoot as mstGetRoot,
   getType as mstGetType,
+  hasEnv as mstHasEnv,
   isArrayType as mstIsArrayType,
   isIdentifierType as mstIsIdentifierType,
   isMapType as mstIsMapType,
@@ -40,8 +41,8 @@ import type {
   IStateTreeNode,
   IType,
   Instance,
-  TreeContext,
   SnapshotIn,
+  TreeContext,
 } from "./types";
 
 export {
@@ -50,13 +51,13 @@ export {
   applyPatch,
   clone,
   createActionTrackingMiddleware2,
-  getRunningActionContext,
   destroy,
   detach,
   escapeJsonPath,
   getIdentifier,
   getPath,
   getPathParts,
+  getRunningActionContext,
   hasParent,
   isActionContextThisOrChildOf,
   isAlive,
@@ -178,7 +179,20 @@ export function getEnv<Env = any>(value: IAnyStateTreeNode): Env {
     return mstGetEnv(value);
   }
 
-  return (getContext(value)?.env ?? {}) as Env;
+  const env = getContext(value)?.env;
+  if (!env) {
+    throw new Error(`Failed to find the environment of ${value}`);
+  }
+
+  return env as Env;
+}
+
+export function hasEnv(value: IAnyStateTreeNode): boolean {
+  if (mstIsStateTreeNode(value)) {
+    return mstHasEnv(value);
+  }
+
+  return !!getContext(value)?.env;
 }
 
 export const getRoot = <T extends IAnyType>(value: IAnyStateTreeNode): Instance<T> => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -209,7 +209,7 @@ export const isRoot = (value: IAnyStateTreeNode): boolean => {
 export function resolveIdentifier<T extends IAnyModelType>(
   type: T,
   target: IStateTreeNode<IAnyType>,
-  identifier: string
+  identifier: string,
 ): Instance<T> | undefined {
   if (mstIsStateTreeNode(target)) {
     if (isType(type)) {
@@ -237,7 +237,7 @@ export const applySnapshot = <T extends IAnyType>(target: IStateTreeNode<T>, sna
 
 export const onSnapshot = <S>(
   target: IStateTreeNode<IType<any, S, any>> | IStateTreeNode<IClassModelType<any, any, S>>,
-  callback: (snapshot: S) => void
+  callback: (snapshot: S) => void,
 ): IDisposer => {
   if (mstIsStateTreeNode(target)) {
     return mstOnSnapshot<S>(target as MSTStateTreeNode, callback);
@@ -295,7 +295,7 @@ export function cast(snapshotOrInstance: any): any {
  * See https://mobx-state-tree.js.org/concepts/async-actions for more info.
  */
 export function flow<R, Args extends any[], This = unknown>(
-  generator: (this: This, ...args: Args) => Generator<PromiseLike<any>, R, any>
+  generator: (this: This, ...args: Args) => Generator<PromiseLike<any>, R, any>,
 ): (...args: Args) => Promise<FlowReturn<R>> {
   // wrap the passed generator in a function which restores the correct value of `this`
   const wrappedGenerator = mstFlow(function* (args: Args, instance: This) {

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -112,7 +112,7 @@ class BaseClassModel {
  * }
  */
 export const ClassModel = <PropsDeclaration extends ModelPropertiesDeclaration>(
-  propertiesDeclaration: PropsDeclaration
+  propertiesDeclaration: PropsDeclaration,
 ): IClassModelType<TypesForModelPropsDeclaration<PropsDeclaration>> => {
   const props = propsFromModelPropsDeclaration(propertiesDeclaration);
 
@@ -137,7 +137,7 @@ export const ClassModel = <PropsDeclaration extends ModelPropertiesDeclaration>(
 export function register<Instance, Klass extends { new (...args: any[]): Instance }>(
   object: Klass,
   tags?: RegistrationTags<Instance>,
-  name?: string
+  name?: string,
 ) {
   let klass = object as any as IClassModelType<any>;
   const mstActions: ModelActions = {};
@@ -204,7 +204,7 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
           throw new RegistrationError(
             `Property ${metadata.property} not found on ${klass} prototype or instance, can't register action for class model. Using ${
               canUsePrototype ? "prototype" : "instance"
-            } to inspect.`
+            } to inspect.`,
           );
         }
 
@@ -214,7 +214,7 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
         }
         if (!actionFunction || !actionFunction.call) {
           throw new RegistrationError(
-            `Property ${metadata.property} found on ${klass} but can't be registered as an action because it isn't a function. It is ${actionFunction}.`
+            `Property ${metadata.property} found on ${klass} but can't be registered as an action because it isn't a function. It is ${actionFunction}.`,
           );
         }
 
@@ -322,7 +322,7 @@ export function volatile(initializer: (instance: any) => any): VolatileDefiner {
     {
       [$volatileDefiner]: true,
       initializer,
-    } as const
+    } as const,
   );
 }
 
@@ -331,7 +331,7 @@ export function volatile(initializer: (instance: any) => any): VolatileDefiner {
  */
 export function extend<T extends Constructor, SubClassProps extends ModelPropertiesDeclaration>(
   klass: T,
-  props: SubClassProps
+  props: SubClassProps,
 ): ExtendedClassModel<T, SubClassProps> {
   const subclass = class extends klass {} as any;
   subclass.properties = {
@@ -352,7 +352,7 @@ export const ensureRegistered = (type: IAnyType) => {
     if ((chain as any)[$requiresRegistration]) {
       if (!(type as any)[$registered]) {
         throw new Error(
-          `Type ${type.name} requires registration but has not been registered yet. Add the @register decorator to it for it to function correctly.`
+          `Type ${type.name} requires registration but has not been registered yet. Add the @register decorator to it for it to function correctly.`,
         );
       }
       break;

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -3,27 +3,20 @@ import type { ModelInitializer } from "./model";
 import { ModelType } from "./model";
 import type { IAnyNodeModelType, INodeModelType } from "./types";
 
-type PropsFromTypes<T> = T extends INodeModelType<infer P, any>
-  ? P
-  : T extends [INodeModelType<infer P, any>, ...infer Tail]
-  ? P & PropsFromTypes<Tail>
-  : {};
+type PropsFromTypes<T> =
+  T extends INodeModelType<infer P, any> ? P : T extends [INodeModelType<infer P, any>, ...infer Tail] ? P & PropsFromTypes<Tail> : {};
 
-type OthersFromTypes<T> = T extends INodeModelType<any, infer O>
-  ? O
-  : T extends [INodeModelType<any, infer O>, ...infer Tail]
-  ? O & OthersFromTypes<Tail>
-  : {};
+type OthersFromTypes<T> =
+  T extends INodeModelType<any, infer O> ? O : T extends [INodeModelType<any, infer O>, ...infer Tail] ? O & OthersFromTypes<Tail> : {};
 
 type ComposeFactory = {
-  <Types extends [IAnyNodeModelType, ...IAnyNodeModelType[]]>(name: string, ...types: Types): INodeModelType<
-    PropsFromTypes<Types>,
-    OthersFromTypes<Types>
-  >;
-  <Types extends [IAnyNodeModelType, ...IAnyNodeModelType[]]>(...types: Types): INodeModelType<
-    PropsFromTypes<Types>,
-    OthersFromTypes<Types>
-  >;
+  <Types extends [IAnyNodeModelType, ...IAnyNodeModelType[]]>(
+    name: string,
+    ...types: Types
+  ): INodeModelType<PropsFromTypes<Types>, OthersFromTypes<Types>>;
+  <Types extends [IAnyNodeModelType, ...IAnyNodeModelType[]]>(
+    ...types: Types
+  ): INodeModelType<PropsFromTypes<Types>, OthersFromTypes<Types>>;
 };
 
 export const compose: ComposeFactory = (nameOrType: IAnyNodeModelType | string, ...types: IAnyNodeModelType[]): IAnyNodeModelType => {

--- a/src/custom.ts
+++ b/src/custom.ts
@@ -26,7 +26,7 @@ export class CustomType<InputType, OutputType> extends BaseType<InputType, Outpu
 }
 
 export const custom = <InputType, OutputType>(
-  options: CustomTypeOptions<InputType, OutputType>
+  options: CustomTypeOptions<InputType, OutputType>,
 ): IType<InputType, OutputType, OutputType> => {
   return new CustomType(options);
 };

--- a/src/enumeration.ts
+++ b/src/enumeration.ts
@@ -4,7 +4,10 @@ import type { IAnyStateTreeNode, TreeContext, ISimpleType, IStateTreeNode } from
 import memoize from "lodash.memoize";
 
 class EnumerationType<EnumOptions extends string> extends BaseType<EnumOptions, EnumOptions, EnumOptions> {
-  constructor(readonly name: string, readonly options: readonly EnumOptions[]) {
+  constructor(
+    readonly name: string,
+    readonly options: readonly EnumOptions[],
+  ) {
     super(types.enumeration<EnumOptions>(name, [...options]));
   }
 
@@ -32,7 +35,7 @@ type EnumerationFactory = {
 
 export const enumeration: EnumerationFactory = <EnumOptions extends string>(
   nameOrOptions: readonly EnumOptions[] | string,
-  options?: readonly EnumOptions[]
+  options?: readonly EnumOptions[],
 ): ISimpleType<EnumOptions> => {
   let name;
   if (typeof nameOrOptions == "string") {

--- a/src/fast-instantiator.ts
+++ b/src/fast-instantiator.ts
@@ -49,7 +49,7 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
         segments.push(this.assignmentExpressionForMapType(key, type));
       } else {
         segments.push(`
-          // instantiate fallback for ${key} of type ${type.name}
+          // instantiate fallback for ${key} of type ${safeTypeName(type)}
           this["${key}"] = ${this.alias(`model.properties["${key}"]`)}.instantiate(
             snapshot?.["${key}"],
             context,
@@ -255,7 +255,7 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
   private assignmentExpressionForArrayType(key: string, type: ArrayType<any>): string {
     if (!isDirectlyAssignableType(type.childrenType) || type.childrenType instanceof DateType) {
       return `
-        // instantiate fallback for ${key} of type ${type.name}
+        // instantiate fallback for ${key} of type ${safeTypeName(type)}
         this["${key}"] = ${this.alias(`model.properties["${key}"]`)}.instantiate(
           snapshot?.["${key}"],
           context,
@@ -308,3 +308,5 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
     return alias;
   }
 }
+
+const safeTypeName = (type: IAnyType) => type.name.replace(/\n/g, "");

--- a/src/model.ts
+++ b/src/model.ts
@@ -26,7 +26,7 @@ import type {
 import { cyrb53 } from "./utils";
 
 export const propsFromModelPropsDeclaration = <Props extends ModelPropertiesDeclaration>(
-  propsDecl: Props
+  propsDecl: Props,
 ): TypesForModelPropsDeclaration<Props> => {
   const props: Record<string, IAnyType> = {};
   for (const name in propsDecl) {
@@ -92,7 +92,7 @@ export const instantiateInstanceFromProperties = (
   snapshot: Record<string, any> | undefined,
   properties: ModelProperties,
   identifierProp: string | undefined,
-  context: TreeContext
+  context: TreeContext,
 ) => {
   for (const propName in properties) {
     const propType = properties[propName];
@@ -139,7 +139,12 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
   private identifierProp: string | undefined;
   private prototype: this["InstanceType"];
 
-  constructor(readonly properties: Props, readonly initializers: ModelInitializer[], mstType: MSTAnyModelType, prototype?: any) {
+  constructor(
+    readonly properties: Props,
+    readonly initializers: ModelInitializer[],
+    mstType: MSTAnyModelType,
+    prototype?: any,
+  ) {
     super(mstType);
     Object.defineProperty(this, "mstType", {
       value: mstType,
@@ -192,14 +197,14 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
   }
 
   props<AdditionalProps extends ModelPropertiesDeclaration>(
-    propsDecl: AdditionalProps
+    propsDecl: AdditionalProps,
   ): ModelType<Props & TypesForModelPropsDeclaration<AdditionalProps>, Others> {
     const props = propsFromModelPropsDeclaration(propsDecl);
     return new ModelType(
       { ...this.properties, ...props },
       this.initializers,
       this.mstType.props(mstPropsFromQuickProps(props)),
-      this.prototype
+      this.prototype,
     );
   }
 
@@ -217,7 +222,7 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
       actions?: Actions;
       views?: Views;
       state?: VolatileState;
-    }
+    },
   ): INodeModelType<Props, Others & Actions & Views & VolatileState> {
     const init = (self: Instance<this>) => {
       const result = fn(self);
@@ -229,7 +234,7 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
     return new ModelType<Props, Others & Actions & Views & VolatileState>(
       this.properties,
       [...this.initializers, init],
-      this.mstType.extend<Actions, Views, VolatileState>(fn)
+      this.mstType.extend<Actions, Views, VolatileState>(fn),
     );
   }
 
@@ -300,7 +305,7 @@ export type ModelFactory = {
 
 export const model: ModelFactory = <Props extends ModelPropertiesDeclaration>(
   nameOrProperties?: string | Props,
-  properties?: Props
+  properties?: Props,
 ): INodeModelType<TypesForModelPropsDeclaration<Props>, {}> => {
   let propsDecl: Props;
   let name = "model";

--- a/src/optional.ts
+++ b/src/optional.ts
@@ -16,17 +16,17 @@ export type DefaultFuncOrValue<T extends IAnyType> = T["InputType"] | T["OutputT
 
 export class OptionalType<
   T extends IAnyType,
-  OptionalValues extends [ValidOptionalValue, ...ValidOptionalValue[]] = [undefined]
+  OptionalValues extends [ValidOptionalValue, ...ValidOptionalValue[]] = [undefined],
 > extends BaseType<T["InputType"] | OptionalValues[number], T["OutputType"], InstanceWithoutSTNTypeForType<T>> {
   constructor(
     readonly type: T,
     readonly defaultValueOrFunc: DefaultFuncOrValue<T>,
-    readonly undefinedValues: OptionalValues = [undefined] as any
+    readonly undefinedValues: OptionalValues = [undefined] as any,
   ) {
     super(
       undefinedValues
         ? mstTypes.optional(type.mstType, defaultValueOrFunc, undefinedValues)
-        : mstTypes.optional(type.mstType, defaultValueOrFunc)
+        : mstTypes.optional(type.mstType, defaultValueOrFunc),
     );
   }
 
@@ -69,14 +69,14 @@ export type OptionalFactory = {
   <T extends IAnyType, OptionalValues extends [ValidOptionalValue, ...ValidOptionalValue[]]>(
     type: T,
     defaultValue: DefaultFuncOrValue<T>,
-    undefinedValues: OptionalValues
+    undefinedValues: OptionalValues,
   ): IOptionalType<T, OptionalValues>;
 };
 
 export const optional: OptionalFactory = <T extends IAnyType, OptionalValues extends [ValidOptionalValue, ...ValidOptionalValue[]]>(
   type: T,
   defaultValue: DefaultFuncOrValue<T>,
-  undefinedValues?: OptionalValues
+  undefinedValues?: OptionalValues,
 ): IOptionalType<T, OptionalValues> => {
   ensureRegistered(type);
   return new OptionalType(type, defaultValue, undefinedValues);

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -24,7 +24,10 @@ const referenceSchemaHash = async (type: string, targetType: IAnyType) => {
 };
 
 export class ReferenceType<TargetType extends IAnyComplexType> extends BaseType<string, string, InstanceWithoutSTNTypeForType<TargetType>> {
-  constructor(readonly targetType: IAnyComplexType, options?: ReferenceOptions<TargetType["mstType"]>) {
+  constructor(
+    readonly targetType: IAnyComplexType,
+    options?: ReferenceOptions<TargetType["mstType"]>,
+  ) {
     super(types.reference(targetType.mstType, options));
   }
 
@@ -50,7 +53,10 @@ export class SafeReferenceType<TargetType extends IAnyComplexType> extends BaseT
   string | undefined,
   InstanceWithoutSTNTypeForType<TargetType> | undefined
 > {
-  constructor(readonly targetType: IAnyComplexType, options?: SafeReferenceOptions<TargetType>) {
+  constructor(
+    readonly targetType: IAnyComplexType,
+    options?: SafeReferenceOptions<TargetType>,
+  ) {
     super(types.safeReference(targetType.mstType, options));
   }
 
@@ -73,7 +79,7 @@ export class SafeReferenceType<TargetType extends IAnyComplexType> extends BaseT
 
 export const reference = <TargetType extends IAnyComplexType>(
   targetType: TargetType,
-  options?: ReferenceOptions<TargetType["mstType"]>
+  options?: ReferenceOptions<TargetType["mstType"]>,
 ): IReferenceType<TargetType> => {
   ensureRegistered(targetType);
   return new ReferenceType(targetType, options);
@@ -81,7 +87,7 @@ export const reference = <TargetType extends IAnyComplexType>(
 
 export const safeReference = <TargetType extends IAnyComplexType>(
   targetType: TargetType,
-  options?: SafeReferenceOptions<TargetType>
+  options?: SafeReferenceOptions<TargetType>,
 ): IMaybeType<IReferenceType<TargetType>> => {
   ensureRegistered(targetType);
   return new SafeReferenceType(targetType, options);

--- a/src/refinement.ts
+++ b/src/refinement.ts
@@ -4,7 +4,10 @@ import { BaseType } from "./base";
 import type { IAnyType, InstanceWithoutSTNTypeForType, TreeContext, IStateTreeNode, IType } from "./types";
 
 class RefinementType<T extends IAnyType> extends BaseType<T["InputType"], T["OutputType"], InstanceWithoutSTNTypeForType<T>> {
-  constructor(readonly type: T, readonly predicate: (snapshot: Instance<T> | Instance<T["mstType"]>) => boolean) {
+  constructor(
+    readonly type: T,
+    readonly predicate: (snapshot: Instance<T> | Instance<T["mstType"]>) => boolean,
+  ) {
     super(types.refinement(type.mstType, predicate));
   }
 
@@ -28,7 +31,7 @@ class RefinementType<T extends IAnyType> extends BaseType<T["InputType"], T["Out
 
 export const refinement = <T extends IAnyType>(
   type: T,
-  predicate: (snapshot: Instance<T> | Instance<T["mstType"]>) => boolean
+  predicate: (snapshot: Instance<T> | Instance<T["mstType"]>) => boolean,
 ): IType<T["InputType"], T["OutputType"], InstanceWithoutSTNTypeForType<T>> => {
   return new RefinementType(type, predicate);
 };

--- a/src/simple.ts
+++ b/src/simple.ts
@@ -10,7 +10,10 @@ export class SimpleType<T> extends BaseType<T, T, T> {
     return new SimpleType(expectedType, mstType);
   }
 
-  constructor(readonly expectedType: string, mstType: MSTSimpleType<T>) {
+  constructor(
+    readonly expectedType: string,
+    mstType: MSTSimpleType<T>,
+  ) {
     super(mstType);
   }
 

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -29,7 +29,7 @@ const snapshot = (value: any): unknown => {
     return Object.fromEntries(
       Array.from(value.entries()).map(([k, v]) => {
         return [k, childrenAreReferences ? v[$identifier] : snapshot(v)];
-      })
+      }),
     );
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,11 +42,8 @@ export type IDateType = IType<Date | number, number, Date>;
 export type IAnyComplexType = IType<any, any, object> | IClassModelType<any, any>;
 
 /** Given any MQT type, get the type of an instance of the MQT type */
-export type InstanceWithoutSTNTypeForType<T extends IAnyType> = T extends IType<any, any, any>
-  ? T["InstanceTypeWithoutSTN"]
-  : T extends IClassModelType<any, any>
-  ? InstanceType<T>
-  : T;
+export type InstanceWithoutSTNTypeForType<T extends IAnyType> =
+  T extends IType<any, any, any> ? T["InstanceTypeWithoutSTN"] : T extends IClassModelType<any, any> ? InstanceType<T> : T;
 
 export interface INodeModelType<Props extends ModelProperties, Others>
   extends IType<
@@ -66,7 +63,7 @@ export interface INodeModelType<Props extends ModelProperties, Others>
       actions?: A;
       views?: V;
       state?: VS;
-    }
+    },
   ): INodeModelType<Props, Others & A & V & VS>;
 }
 
@@ -85,7 +82,7 @@ export interface IAnyNodeModelType extends IType<any, any, any> {
       actions?: A;
       views?: V;
       state?: VS;
-    }
+    },
   ): IAnyNodeModelType;
 }
 
@@ -97,7 +94,7 @@ export type ExtendedClassModel<
   SubClassProps extends ModelPropertiesDeclaration,
   Props extends ModelProperties = TypesForModelPropsDeclaration<SubClassProps>,
   InputType = InputsForModel<InputTypesForModelProps<Props>>,
-  OutputType = OutputTypesForModelProps<Props>
+  OutputType = OutputTypesForModelProps<Props>,
 > = T & {
   InputType: InputType;
   OutputType: OutputType;
@@ -124,7 +121,7 @@ export type ExtendedClassModel<
 export interface IClassModelType<
   Props extends ModelProperties,
   InputType = InputsForModel<InputTypesForModelProps<Props>>,
-  OutputType = OutputTypesForModelProps<Props>
+  OutputType = OutputTypesForModelProps<Props>,
 > {
   readonly [$quickType]: undefined;
   readonly [$registered]: true;
@@ -141,7 +138,7 @@ export interface IClassModelType<
    */
   extend<T extends Constructor, SubClassProps extends ModelPropertiesDeclaration>(
     this: T,
-    subclassProps: SubClassProps
+    subclassProps: SubClassProps,
   ): ExtendedClassModel<T, SubClassProps>;
 
   /** @hidden */
@@ -304,12 +301,12 @@ export type TypesForModelPropsDeclaration<T extends ModelPropertiesDeclaration> 
   [K in keyof T]: T[K] extends IAnyType
     ? T[K]
     : T[K] extends string
-    ? IOptionalType<ISimpleType<string>, [undefined]>
-    : T[K] extends number
-    ? IOptionalType<ISimpleType<number>, [undefined]>
-    : T[K] extends boolean
-    ? IOptionalType<ISimpleType<boolean>, [undefined]>
-    : IOptionalType<IDateType, [undefined]>;
+      ? IOptionalType<ISimpleType<string>, [undefined]>
+      : T[K] extends number
+        ? IOptionalType<ISimpleType<number>, [undefined]>
+        : T[K] extends boolean
+          ? IOptionalType<ISimpleType<boolean>, [undefined]>
+          : IOptionalType<IDateType, [undefined]>;
 };
 
 export type InputTypesForModelProps<T extends ModelProperties> = {

--- a/src/union.ts
+++ b/src/union.ts
@@ -1,13 +1,13 @@
 import memoize from "lodash.memoize";
 import type { UnionOptions as MSTUnionOptions } from "mobx-state-tree";
 import { types as mstTypes } from "mobx-state-tree";
+import { isModelType, isType } from "./api";
 import { BaseType } from "./base";
 import { ensureRegistered, isClassModel } from "./class-model";
-import type { IAnyType, InstanceWithoutSTNTypeForType, TreeContext, IStateTreeNode, IUnionType } from "./types";
-import { OptionalType } from "./optional";
-import { isModelType, isType } from "./api";
-import { LiteralType } from "./simple";
 import { InvalidDiscriminatorError } from "./errors";
+import { OptionalType } from "./optional";
+import { LiteralType } from "./simple";
+import type { IAnyType, IStateTreeNode, IUnionType, InstanceWithoutSTNTypeForType, TreeContext } from "./types";
 import { cyrb53 } from "./utils";
 
 export type ITypeDispatcher = (snapshot: any) => IAnyType;
@@ -109,7 +109,7 @@ class UnionType<Types extends IAnyType[]> extends BaseType<
 
     super(
       mstTypes.union(
-        { ...options, dispatcher: dispatcher ? (snapshot) => dispatcher!(snapshot).mstType : undefined },
+        { ...options, dispatcher: dispatcher ? (snapshot) => dispatcher(snapshot).mstType : undefined },
         ...types.map((x) => x.mstType),
       ),
     );

--- a/src/union.ts
+++ b/src/union.ts
@@ -52,7 +52,7 @@ const buildDiscriminatorTypeMap = (types: IAnyType[], discriminator: string) => 
       map[type.value] = instantiateAsType;
     } else {
       throw new InvalidDiscriminatorError(
-        `Can't use the discriminator property \`${discriminator}\` on the type \`${type}\` as it is of a type who's value can't be determined at union creation time.`
+        `Can't use the discriminator property \`${discriminator}\` on the type \`${type}\` as it is of a type who's value can't be determined at union creation time.`,
       );
     }
   };
@@ -72,7 +72,10 @@ class UnionType<Types extends IAnyType[]> extends BaseType<
 > {
   readonly dispatcher?: ITypeDispatcher;
 
-  constructor(readonly types: Types, readonly options: UnionOptions = {}) {
+  constructor(
+    readonly types: Types,
+    readonly options: UnionOptions = {},
+  ) {
     let dispatcher: ITypeDispatcher | undefined = undefined;
 
     if (options?.dispatcher) {
@@ -95,8 +98,8 @@ class UnionType<Types extends IAnyType[]> extends BaseType<
             `Discriminator property value \`${discriminatorValue}\` for property \`${
               options.discriminator
             }\` on incoming snapshot didn't correspond to a type. Options: ${Object.keys(discriminatorToTypeMap).join(
-              ", "
-            )}. Snapshot was \`${JSON.stringify(snapshot)}\``
+              ", ",
+            )}. Snapshot was \`${JSON.stringify(snapshot)}\``,
           );
         }
 
@@ -107,8 +110,8 @@ class UnionType<Types extends IAnyType[]> extends BaseType<
     super(
       mstTypes.union(
         { ...options, dispatcher: dispatcher ? (snapshot) => dispatcher!(snapshot).mstType : undefined },
-        ...types.map((x) => x.mstType)
-      )
+        ...types.map((x) => x.mstType),
+      ),
     );
 
     this.dispatcher = dispatcher;


### PR DESCRIPTION
I packed a bunch of stuff into one PR, but split it up into separate commits:

* Bumped most dependencies
    * Not bumping deep-freeze-es6, which jest is unhappy with for any version >= 2.
    * Not bumping eslint, because v9 isn't backwards compatible. Best to wait a few months 
for it to settle and the plugin ecosystem to support v9.
    * Fixed any linting issues due to bumping prettier/TS
* We were always checking the `type` argument passed to `ensureRegistered` for registration, and not each part of the prototype chain.
* Increases `initCount` in our benchmarks so that we don't get any unfortunate issues where a benchmark has some JITed and non-JITed samples. Not sure if the value is high enough to ensure things will be JIT-ed, but I figure it's still an improvement.

**TODO**
- [ ] Test out this branch in the Gadget repo (but opening for review early)
- [ ] Follow up with a separate PR to bump to 0.7.0