### PR TITLE
extending unions

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -3,6 +3,7 @@ import { $quickType } from "./symbols";
 import type { IAnyStateTreeNode, IStateTreeNode, TreeContext, StateTreeNode } from "./types";
 
 export abstract class BaseType<InputType, OutputType, InstanceType> {
+  /** @internal */
   readonly [$quickType] = undefined;
 
   readonly InputType!: InputType;

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -74,6 +74,7 @@ class BaseClassModel {
   static isMQTClassModel = true as const;
   static mstType: MSTIModelType<any, any>;
   static readonly [$requiresRegistration] = true;
+  /** @internal */
   static readonly [$quickType] = true;
 
   static extend(props: ModelPropertiesDeclaration) {

--- a/src/fast-instantiator.ts
+++ b/src/fast-instantiator.ts
@@ -49,7 +49,7 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
         segments.push(this.assignmentExpressionForMapType(key, type));
       } else {
         segments.push(`
-          // instantiate fallback for ${key} of type ${type.name}
+          // instantiate fallback for ${key} of type ${safeTypeName(type)}
           this["${key}"] = ${this.alias(`model.properties["${key}"]`)}.instantiate(
             snapshot?.["${key}"],
             context,
@@ -255,7 +255,7 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
   private assignmentExpressionForArrayType(key: string, type: ArrayType<any>): string {
     if (!isDirectlyAssignableType(type.childrenType) || type.childrenType instanceof DateType) {
       return `
-        // instantiate fallback for ${key} of type ${type.name}
+        // instantiate fallback for ${key} of type ${safeTypeName(type)}
         this["${key}"] = ${this.alias(`model.properties["${key}"]`)}.instantiate(
           snapshot?.["${key}"],
           context,
@@ -308,3 +308,5 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
     return alias;
   }
 }
+
+const safeTypeName = (type: IAnyType) => type.name.replace(/\n/g, "");

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { lazyUnion, union } from "./union";
 
 export * from "./api";
 export * from "./types";
+export { $type } from "./symbols";
 
 export const types = {
   boolean: SimpleType.for("boolean", mstTypes.boolean),

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -10,7 +10,6 @@ export const $parent = Symbol.for("MQT_parent");
 /** @hidden */
 export const $identifier = Symbol.for("MQT_identifier");
 
-/** @hidden */
 export const $type = Symbol.for("MQT_type");
 
 /** @hidden */

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,7 +110,7 @@ export type ExtendedClassModel<
 /**
  * `IClassModelType` represents the type of MQT class models. This is the class-level type, not the instance level type, so it has a typed `new()` and all the static functions/properties of a MQT class model.
  *
- * Note: `IClassModelType` is regrettably *not* an `IType`. `IClassModelType` is an interface that all class model classes implement. It's also the concrete type of the base class models returned by the ClassModel class factory. It'd be great if we could make `IClassModelType` extend `IType`, but, we would need to ensure the `Instance` part of `IType` is updated to reference the final version of the declared class. Crucially, there's no TypeScript way to get the resulting type of a class *after* it has been defined to then start referring to it within an interface that the class implements. Decorators don't let us get a reference to the finished type of a class, nor do they let us return a new type that could reference it, so, we can't mutate the type of a defined class model. Hence, we can't make `IClassModelType` extend `IType` without it capturing a reference to an outdated `Instance` type that doesn't have the methods / properties added after class extension. Sad.
+ * Note: `IClassModelType` is regrettably *not* an `IType`. `IClassModelType` is an interface that all class model classes implement. It's also the concrete type of the base class models returned by the ClassModel class factory. It'd be great if we could make `IClassModelType` extend `IType`, but, we would need to ensure the `Instance` part of `IType` is updated to reference the final version of the declared class. Crucially, there's no TypeScript way to get the resulting type of a class *after* it has been defined, to then start referring to it within an interface that the class implements. Decorators don't let us get a reference to the finished type of a class, nor do they let us return a new type that could reference it, so, we can't mutate the type of a defined class model. Hence, we can't make `IClassModelType` extend `IType` without it capturing a reference to an outdated `Instance` type that doesn't have the methods / properties added after class extension. Sad.
  *
  * Instead, we have this type, and we compute the instance type of a class model in a different way than `IType`. The type of an instance of a class is the class itself. Whereas usually, we need to do:
  *
@@ -208,11 +208,9 @@ export type IMapType<T extends IAnyType> = IType<Record<string, T["InputType"]> 
 
 export type IArrayType<T extends IAnyType> = IType<Array<T["InputType"]> | undefined, T["OutputType"][], IMSTArray<T>>;
 
-export type IUnionType<Types extends [IAnyType, ...IAnyType[]]> = IType<
-  Types[number]["InputType"],
-  Types[number]["OutputType"],
-  InstanceWithoutSTNTypeForType<Types[number]>
->;
+export type IUnionType<Types extends [IAnyType, ...IAnyType[]]> = Types[number] extends IAnyClassModelType
+  ? Types[number]
+  : IType<Types[number]["InputType"], Types[number]["OutputType"], InstanceWithoutSTNTypeForType<Types[number]>>;
 
 // Utility types
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type { IJsonPatch, IMiddlewareEvent, IPatchRecorder, ReferenceOptions, Un
 export type Constructor<T = {}> = new (...args: any[]) => T;
 
 export interface IType<InputType, OutputType, InstanceType> {
+  /** @internal */
   readonly [$quickType]: undefined;
 
   readonly InputType: InputType;
@@ -126,7 +127,9 @@ export interface IClassModelType<
   InputType = InputsForModel<InputTypesForModelProps<Props>>,
   OutputType = OutputTypesForModelProps<Props>
 > {
+  /** @internal */
   readonly [$quickType]: undefined;
+  /** @internal */
   readonly [$registered]: true;
 
   readonly InputType: InputType;


### PR DESCRIPTION
- Export the $type symbol and mark the other properties as internal for portable type definitions
- Ensure that unions can be extended with `extends`
- Fix fast instantiator failing to compile when the typename has newlines in it
