### PR TITLE
Bump MQT to version 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/mobx-quick-tree",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "A mirror of mobx-state-tree's API to construct fast, read-only instances that share all the same views",
   "source": "src/index.ts",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Compare: https://github.com/gadget-inc/mobx-quick-tree/compare/0.6.2...HEAD

Rough outline of changes:

1. `getSnapshot` now properly snapshots reference types in maps/arrays, returning the identifier instead of the referenced model (https://github.com/gadget-inc/mobx-quick-tree/pull/82)
2. Implemented `resolveIdentifier` for readonly nodes (https://github.com/gadget-inc/mobx-quick-tree/pull/79)
3. Bumped to latest version of `typescript`, `mobx-state-tree`, and `mobx`.