### PR TITLE
Faster get with memos class

### DIFF
--- a/src/fast-getter.ts
+++ b/src/fast-getter.ts
@@ -1,0 +1,73 @@
+import type { PropertyMetadata, ViewMetadata } from "./class-model";
+import { getPropertyDescriptor } from "./class-model";
+import { RegistrationError } from "./errors";
+import { $memos, $notYetMemoized, $readOnly } from "./symbols";
+
+/** Assemble a function for getting the value of a readonly instance very quickly with static dispatch to properties */
+
+export class FastGetBuilder {
+  memoizableProperties: string[];
+  memosClass: { new (...args: any[]): any };
+
+  constructor(
+    metadatas: PropertyMetadata[],
+    readonly klass: { new (...args: any[]): any },
+  ) {
+    this.memoizableProperties = metadatas
+      .filter((metadata): metadata is ViewMetadata => {
+        if (metadata.type !== "view") return false;
+        const property = metadata.property;
+        const descriptor = getPropertyDescriptor(klass.prototype, property);
+        if (!descriptor) {
+          throw new RegistrationError(`Property ${property} not found on ${klass} prototype, can't register view for class model`);
+        }
+        return descriptor.get !== undefined;
+      })
+      .map((metadata) => metadata.property);
+
+    this.memosClass = class {};
+    for (const property of this.memoizableProperties) {
+      this.memosClass.prototype[property] = $notYetMemoized;
+    }
+  }
+
+  constructorStatements() {
+    return `
+      this[$memos] = null;
+    `;
+  }
+
+  buildGetter(property: string, descriptor: PropertyDescriptor) {
+    const source = `
+      (
+        function build({ $readOnly, $memos, $notYetMemoized, getValue, MemosClass }) {
+          return function get${property}(model, imports) {
+            if (!this[$readOnly]) return getValue.call(this);
+            if (!this[$memos]) {
+              this[$memos] = new MemosClass();
+            }
+
+            let value = this[$memos].${property};
+            if (value != $notYetMemoized) {
+              return value;
+            }
+
+            value = getValue.call(this);
+            this[$memos].${property} = value;
+            return value;
+          }
+        }
+      )
+      //# sourceURL=mqt-eval/dynamic/${this.klass.name}-${property}-get.js
+    `;
+
+    try {
+      const builder = eval(source);
+      return builder({ $readOnly, $memos, $notYetMemoized, MemosClass: this.memosClass, getValue: descriptor.get });
+    } catch (error) {
+      console.error(`Error building getter for ${this.klass.name}#${property}`);
+      console.error(`Compiled source:\n${source}`);
+      throw error;
+    }
+  }
+}

--- a/src/fast-instantiator.ts
+++ b/src/fast-instantiator.ts
@@ -1,17 +1,21 @@
 import { ArrayType, QuickArray } from "./array";
+import type { FastGetBuilder } from "./fast-getter";
 import { FrozenType } from "./frozen";
 import { MapType, QuickMap } from "./map";
 import { OptionalType } from "./optional";
 import { ReferenceType, SafeReferenceType } from "./reference";
 import { DateType, IntegerType, LiteralType, SimpleType } from "./simple";
-import { $context, $identifier, $memoizedKeys, $memos, $parent, $readOnly, $type } from "./symbols";
+import { $context, $identifier, $memos, $notYetMemoized, $parent, $readOnly, $type } from "./symbols";
 import type { IAnyType, IClassModelType, ValidOptionalValue } from "./types";
 
 /**
  * Compiles a fast function for taking snapshots and turning them into instances of a class model.
  **/
-export const buildFastInstantiator = <T extends IClassModelType<Record<string, IAnyType>, any, any>>(model: T): T => {
-  return new InstantiatorBuilder(model).build();
+export const buildFastInstantiator = <T extends IClassModelType<Record<string, IAnyType>, any, any>>(
+  model: T,
+  fastGetters: FastGetBuilder,
+): T => {
+  return new InstantiatorBuilder(model, fastGetters).build();
 };
 
 type DirectlyAssignableType = SimpleType<any> | IntegerType | LiteralType<any> | DateType;
@@ -28,7 +32,10 @@ const isDirectlyAssignableType = (type: IAnyType): type is DirectlyAssignableTyp
 class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, any, any>> {
   aliases = new Map<string, string>();
 
-  constructor(readonly model: T) {}
+  constructor(
+    readonly model: T,
+    readonly getters: FastGetBuilder,
+  ) {}
 
   build(): T {
     const segments: string[] = [];
@@ -74,6 +81,8 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
     `);
     }
 
+    segments.push(this.getters.constructorStatements());
+
     let className = this.model.name;
     if (!className || className.trim().length == 0) {
       className = "AnonymousModel";
@@ -81,9 +90,6 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
 
     const defineClassStatement = `
       return class ${className} extends model {
-        [$memos] = null;
-        [$memoizedKeys] = null;
-
         static createReadOnly = (snapshot, env) => {
           const context = {
             referenceCache: new Map(),
@@ -137,7 +143,7 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
     `;
 
     const aliasFuncBody = `
-    const { QuickMap, QuickArray, $identifier, $context, $parent, $memos, $memoizedKeys, $readOnly, $type } = imports;
+    const { QuickMap, QuickArray, $identifier, $context, $parent, $memos, $notYetMemoized, $readOnly, $type } = imports;
 
     ${Array.from(this.aliases.entries())
       .map(([expression, alias]) => `const ${alias} = ${expression};`)
@@ -167,9 +173,9 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
         $context,
         $parent,
         $memos,
-        $memoizedKeys,
         $readOnly,
         $type,
+        $notYetMemoized,
         QuickMap,
         QuickArray,
       }) as T;

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -38,13 +38,13 @@ export const $registered = Symbol.for("MQT_registered");
 export const $volatileDefiner = Symbol.for("MQT_volatileDefiner");
 
 /**
- * The values of memoized properties on an MQT instance
+ * The list of properties which have been memoized
  * @hidden
  **/
 export const $memos = Symbol.for("mqt:class-model-memos");
 
 /**
- * The list of properties which have been memoized
+ * The value we use in the memos map when we haven't populated the memo yet
  * @hidden
  **/
-export const $memoizedKeys = Symbol.for("mqt:class-model-memoized-keys");
+export const $notYetMemoized = Symbol.for("mqt:not-yet-memoized");


### PR DESCRIPTION
This implements a better performing getter function for readonly instances. Before this, we used the same definition of the getter function for all views, which ended up megamorphic, because it accessed a very wide variety of properties for every instance! Instead, this evals a monomorphic getter for each one. I also changed the object that stores the memos to have a fixed shape from birth by evaling it out as well.

I also changed us to use one object to store all the memoized values, instead of two. We were previously using two in order to implement memoization of undefined and null correctly, but with the new strategy to initialize an object with slots for every memo from the start, we can populate it with a `$notYetMemoized` symbol that indicates if we have memoized or not.

And finally -- the object that stores the memos itself also has a dynamic shape, so it's also optimized! We create a new dynamic class per ClassModel that has all the properties we might memoize on it's prototype, which makes it fast to instantiate but have a stable shape.
