### PR TITLE
Faster cached view version 7: values right on the instance

### DIFF
--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -5,12 +5,11 @@ import type { IModelType as MSTIModelType, ModelActions } from "mobx-state-tree"
 import { types as mstTypes } from "mobx-state-tree";
 import { RegistrationError } from "./errors";
 import { buildFastInstantiator } from "./fast-instantiator";
+import { FastGetBuilder } from "./fast-getter";
 import { defaultThrowAction, mstPropsFromQuickProps, propsFromModelPropsDeclaration } from "./model";
 import {
   $context,
   $identifier,
-  $memoizedKeys,
-  $memos,
   $originalDescriptor,
   $parent,
   $quickType,
@@ -40,7 +39,7 @@ type ActionMetadata = {
 };
 
 /** @internal */
-type ViewMetadata = {
+export type ViewMetadata = {
   type: "view";
   property: string;
 };
@@ -53,7 +52,8 @@ export type VolatileMetadata = {
 };
 
 type VolatileInitializer<T> = (instance: T) => Record<string, any>;
-type PropertyMetadata = ActionMetadata | ViewMetadata | VolatileMetadata;
+/** @internal */
+export type PropertyMetadata = ActionMetadata | ViewMetadata | VolatileMetadata;
 
 const metadataPrefix = "mqt:properties";
 const viewKeyPrefix = `${metadataPrefix}:view`;
@@ -90,10 +90,6 @@ class BaseClassModel {
   readonly [$parent]?: IStateTreeNode | null;
   /** @hidden */
   [$identifier]?: any;
-  /** @hidden */
-  [$memos]!: Record<string, any> | null;
-  /** @hidden */
-  [$memoizedKeys]!: Record<string, boolean> | null;
 }
 
 /**
@@ -158,6 +154,8 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
     });
   }
 
+  const fastGetters = new FastGetBuilder(metadatas, klass);
+
   for (const metadata of metadatas) {
     switch (metadata.type) {
       case "view": {
@@ -171,16 +169,7 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
         if (descriptor.get) {
           Object.defineProperty(klass.prototype, property, {
             ...descriptor,
-            get() {
-              if (!this[$readOnly]) return descriptor.get!.call(this);
-              if (this[$memoizedKeys]?.[property]) return this[$memos][property];
-              this[$memoizedKeys] ??= {};
-              this[$memos] ??= {};
-              const value: any = descriptor.get!.call(this);
-              this[$memoizedKeys][property] = true;
-              this[$memos][property] = value;
-              return value;
-            },
+            get: fastGetters.buildGetter(property, descriptor),
           });
         }
 
@@ -278,7 +267,7 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
   //   - .createReadOnly
   //   - .is
   //   - .instantiate
-  return buildFastInstantiator(klass) as any;
+  return buildFastInstantiator(klass, fastGetters) as any;
 }
 
 /**
@@ -449,7 +438,7 @@ function allPrototypeFunctionProperties(obj: any): string[] {
  * Get the property descriptor for a property from anywhere in the prototype chain
  * Similar to Object.getOwnPropertyDescriptor, but without the own bit
  */
-function getPropertyDescriptor(obj: any, property: string) {
+export function getPropertyDescriptor(obj: any, property: string) {
   while (obj) {
     const descriptor = Object.getOwnPropertyDescriptor(obj, property);
     if (descriptor) {

--- a/src/fast-getter.ts
+++ b/src/fast-getter.ts
@@ -1,0 +1,68 @@
+import type { PropertyMetadata, ViewMetadata } from "./class-model";
+import { getPropertyDescriptor } from "./class-model";
+import { RegistrationError } from "./errors";
+import { $notYetMemoized, $readOnly } from "./symbols";
+
+/** Assemble a function for getting the value of a readonly instance very quickly with static dispatch to properties */
+export class FastGetBuilder {
+  memoizableProperties: string[];
+
+  constructor(
+    metadatas: PropertyMetadata[],
+    readonly klass: { new (...args: any[]): any },
+  ) {
+    this.memoizableProperties = metadatas
+      .filter((metadata): metadata is ViewMetadata => {
+        if (metadata.type !== "view") return false;
+        const property = metadata.property;
+        const descriptor = getPropertyDescriptor(klass.prototype, property);
+        if (!descriptor) {
+          throw new RegistrationError(`Property ${property} not found on ${klass} prototype, can't register view for class model`);
+        }
+        return descriptor.get !== undefined;
+      })
+      .map((metadata) => metadata.property);
+  }
+
+  outerClosureStatements(className: string) {
+    return this.memoizableProperties
+      .map(
+        (property) => `
+          const ${property}Memo = Symbol.for("mqt/${property}-memo");
+          ${className}.prototype[${property}Memo] = $notYetMemoized;
+        `,
+      )
+      .join("\n");
+  }
+
+  buildGetter(property: string, descriptor: PropertyDescriptor) {
+    const $memo = Symbol.for(`mqt/${property}-memo`);
+    const source = `
+      (
+        function build({ $readOnly, $memo, $notYetMemoized, getValue }) {
+          return function get${property}(model, imports) {
+            if (!this[$readOnly]) return getValue.call(this);
+            let value = this[$memo];
+            if (value !== $notYetMemoized) {
+              return value;
+            }
+
+            value = getValue.call(this);
+            this[$memo] = value;
+            return value;
+          }
+        }
+      )
+      //# sourceURL=mqt-eval/dynamic/${this.klass.name}-${property}-get.js
+    `;
+
+    try {
+      const builder = eval(source);
+      return builder({ $readOnly, $memo, $notYetMemoized, getValue: descriptor.get });
+    } catch (error) {
+      console.error(`Error building getter for ${this.klass.name}#${property}`);
+      console.error(`Compiled source:\n${source}`);
+      throw error;
+    }
+  }
+}

--- a/src/fast-instantiator.ts
+++ b/src/fast-instantiator.ts
@@ -1,17 +1,21 @@
 import { ArrayType, QuickArray } from "./array";
+import type { FastGetBuilder } from "./fast-getter";
 import { FrozenType } from "./frozen";
 import { MapType, QuickMap } from "./map";
 import { OptionalType } from "./optional";
 import { ReferenceType, SafeReferenceType } from "./reference";
 import { DateType, IntegerType, LiteralType, SimpleType } from "./simple";
-import { $context, $identifier, $memoizedKeys, $memos, $parent, $readOnly, $type } from "./symbols";
+import { $context, $identifier, $notYetMemoized, $parent, $readOnly, $type } from "./symbols";
 import type { IAnyType, IClassModelType, ValidOptionalValue } from "./types";
 
 /**
  * Compiles a fast function for taking snapshots and turning them into instances of a class model.
  **/
-export const buildFastInstantiator = <T extends IClassModelType<Record<string, IAnyType>, any, any>>(model: T): T => {
-  return new InstantiatorBuilder(model).build();
+export const buildFastInstantiator = <T extends IClassModelType<Record<string, IAnyType>, any, any>>(
+  model: T,
+  fastGetters: FastGetBuilder,
+): T => {
+  return new InstantiatorBuilder(model, fastGetters).build();
 };
 
 type DirectlyAssignableType = SimpleType<any> | IntegerType | LiteralType<any> | DateType;
@@ -28,7 +32,10 @@ const isDirectlyAssignableType = (type: IAnyType): type is DirectlyAssignableTyp
 class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, any, any>> {
   aliases = new Map<string, string>();
 
-  constructor(readonly model: T) {}
+  constructor(
+    readonly model: T,
+    readonly getters: FastGetBuilder,
+  ) {}
 
   build(): T {
     const segments: string[] = [];
@@ -80,10 +87,7 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
     }
 
     const defineClassStatement = `
-      return class ${className} extends model {
-        [$memos] = null;
-        [$memoizedKeys] = null;
-
+      class ${className} extends model {
         static createReadOnly = (snapshot, env) => {
           const context = {
             referenceCache: new Map(),
@@ -137,13 +141,17 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
     `;
 
     const aliasFuncBody = `
-    const { QuickMap, QuickArray, $identifier, $context, $parent, $memos, $memoizedKeys, $readOnly, $type } = imports;
+    const { QuickMap, QuickArray, $identifier, $context, $parent, $notYetMemoized, $readOnly, $type } = imports;
 
     ${Array.from(this.aliases.entries())
       .map(([expression, alias]) => `const ${alias} = ${expression};`)
       .join("\n")}
 
     ${defineClassStatement}
+
+    ${this.getters.outerClosureStatements(className)}
+
+    return ${className}
   `;
 
     // console.log(`function for ${this.model.name}`, "\n\n\n", aliasFuncBody, "\n\n\n");
@@ -166,10 +174,9 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
         $identifier,
         $context,
         $parent,
-        $memos,
-        $memoizedKeys,
         $readOnly,
         $type,
+        $notYetMemoized,
         QuickMap,
         QuickArray,
       }) as T;

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -38,13 +38,7 @@ export const $registered = Symbol.for("MQT_registered");
 export const $volatileDefiner = Symbol.for("MQT_volatileDefiner");
 
 /**
- * The values of memoized properties on an MQT instance
+ * The value we use in the memos map when we haven't populated the memo yet
  * @hidden
  **/
-export const $memos = Symbol.for("mqt:class-model-memos");
-
-/**
- * The list of properties which have been memoized
- * @hidden
- **/
-export const $memoizedKeys = Symbol.for("mqt:class-model-memoized-keys");
+export const $notYetMemoized = Symbol.for("mqt:not-yet-memoized");


### PR DESCRIPTION
This implements a better performing getter function for readonly instances. Before this, we used the same definition of the getter function for all views, which ended up megamorphic, because it accessed a very wide variety of properties for every instance! Instead, this evals a monomorphic getter for each one. I also changed the object that stores the memos to have a fixed shape from birth by evaling it out as well.

I also changed us to use the object itself to store all the memoized values, instead of two other tracker objects. We were previously using the trackers in order to implement memoization of undefined and null correctly. Now, we set up symbol properties to store all the memos, but on the prototype of the class model. This means we don't spend any time setting them up during construction, but the JS VM knows the shape of the memos ahead of time! Less memory and same speed woop woop! Then, when memoizing, we can stash the value under that symbol key, which means fewer property accesses and lookups to fetch it.

Replaces #90