### PR TITLE
Run node v22 in dev and CI

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699343069,
-        "narHash": "sha256-s7BBhyLA6MI6FuJgs4F/SgpntHBzz40/qV0xLPW6A1Q=",
+        "lastModified": 1717112898,
+        "narHash": "sha256-7R2ZvOnvd9h8fDd65p0JnB7wXfUvreox3xFdYWd1BnY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ec750fd01963ab6b20ee1f0cb488754e8036d89d",
+        "rev": "6132b0f6e344ce2fe34fc051b72fb46e34f668e0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,9 +21,9 @@
           packages =
             rec {
               bash = pkgs.bash;
-              nodejs = pkgs.nodejs_21;
-              pnpm = pkgs.nodejs_21.pkgs.pnpm;
-              npm = pkgs.nodejs_21.pkgs.npm;
+              nodejs = pkgs.nodejs_22;
+              pnpm = pkgs.nodejs_22.pkgs.pnpm;
+              npm = pkgs.nodejs_22.pkgs.npm;
             };
 
           devShell = pkgs.mkShell {


### PR DESCRIPTION
This upgrades the dev environment for MQT to node v22 from node v21. According to codspeed at least, the v8 upgrade buys at least 10% better performance across the board!