### PR TITLE
Ensure types.maybe(types.reference()) types are resolved late after construction

### DIFF
--- a/spec/class-model-references.spec.ts
+++ b/spec/class-model-references.spec.ts
@@ -1,6 +1,9 @@
+import { read } from "fs";
 import type { IAnyClassModelType, InstanceWithoutSTNTypeForType, IReferenceType, StateTreeNode } from "../src";
 import { Instance, types } from "../src";
 import { action, ClassModel, register } from "../src/class-model";
+import { Apple } from "./fixtures/FruitAisle";
+import { NameExample } from "./fixtures/NameExample";
 import { create } from "./helpers";
 
 @register
@@ -37,132 +40,175 @@ class Root extends ClassModel({
   refs: types.array(Referrable),
 }) {}
 
-describe("clas model references", () => {
-  test("can resolve valid references", () => {
-    const root = create(
-      Root,
-      {
-        model: {
-          ref: "item-a",
-        },
-        refs: [
-          { key: "item-a", count: 12 },
-          { key: "item-b", count: 523 },
-        ],
-      },
-      true,
-    );
-
-    expect(root.model.ref).toEqual(
-      expect.objectContaining({
-        key: "item-a",
-        count: 12,
-      }),
-    );
-  });
-
-  test("throws for invalid refs", () => {
-    const createRoot = () =>
-      create(
+describe("class model references", () => {
+  describe.each([
+    ["read-only", true],
+    ["observable", false],
+  ])("%s", (_name, readOnly) => {
+    test("can resolve valid references", () => {
+      const root = create(
         Root,
         {
           model: {
-            ref: "item-c",
+            ref: "item-a",
           },
           refs: [
             { key: "item-a", count: 12 },
             { key: "item-b", count: 523 },
           ],
         },
-        true,
+        readOnly,
       );
 
-    expect(createRoot).toThrow();
-  });
+      expect(root.model.ref).toEqual(
+        expect.objectContaining({
+          key: "item-a",
+          count: 12,
+        }),
+      );
+    });
 
-  test("can resolve valid safe references", () => {
-    const root = create(
-      Root,
-      {
-        model: {
-          ref: "item-a",
-          safeRef: "item-b",
+    test("throws for invalid refs", () => {
+      const createRoot = () => {
+        const instance = create(
+          Root,
+          {
+            model: {
+              ref: "item-c",
+            },
+            refs: [
+              { key: "item-a", count: 12 },
+              { key: "item-b", count: 523 },
+            ],
+          },
+          readOnly,
+        );
+        instance.model.ref;
+      };
+
+      expect(createRoot).toThrow();
+    });
+
+    test("can resolve valid safe references", () => {
+      const root = create(
+        Root,
+        {
+          model: {
+            ref: "item-a",
+            safeRef: "item-b",
+          },
+          refs: [
+            { key: "item-a", count: 12 },
+            { key: "item-b", count: 523 },
+          ],
         },
-        refs: [
-          { key: "item-a", count: 12 },
-          { key: "item-b", count: 523 },
-        ],
-      },
-      true,
-    );
+        readOnly,
+      );
 
-    expect(root.model.safeRef).toEqual(
-      expect.objectContaining({
-        key: "item-b",
-        count: 523,
-      }),
-    );
-  });
+      expect(root.model.safeRef).toEqual(
+        expect.objectContaining({
+          key: "item-b",
+          count: 523,
+        }),
+      );
+    });
 
-  test("does not throw for invalid safe references", () => {
-    const root = create(
-      Root,
-      {
-        model: {
-          ref: "item-a",
-          safeRef: "item-c",
+    test("does not throw for invalid safe references", () => {
+      const root = create(
+        Root,
+        {
+          model: {
+            ref: "item-a",
+            safeRef: "item-c",
+          },
+          refs: [
+            { key: "item-a", count: 12 },
+            { key: "item-b", count: 523 },
+          ],
         },
-        refs: [
-          { key: "item-a", count: 12 },
-          { key: "item-b", count: 523 },
-        ],
-      },
-      true,
-    );
+        readOnly,
+      );
 
-    expect(root.model.safeRef).toBeUndefined();
-  });
+      expect(root.model.safeRef).toBeUndefined();
+    });
 
-  test("references are equal to the instances they refer to", () => {
-    const root = create(
-      Root,
-      {
-        model: {
-          ref: "item-a",
-          safeRef: "item-b",
+    test("references are equal to the instances they refer to", () => {
+      const root = create(
+        Root,
+        {
+          model: {
+            ref: "item-a",
+            safeRef: "item-b",
+          },
+          refs: [
+            { key: "item-a", count: 12 },
+            { key: "item-b", count: 523 },
+          ],
         },
-        refs: [
-          { key: "item-a", count: 12 },
-          { key: "item-b", count: 523 },
-        ],
-      },
-      true,
-    );
+        readOnly,
+      );
 
-    expect(root.model.ref).toBe(root.refs[0]);
-    expect(root.model.ref).toEqual(root.refs[0]);
-    expect(root.model.ref).toStrictEqual(root.refs[0]);
-  });
+      expect(root.model.ref).toBe(root.refs[0]);
+      expect(root.model.ref).toEqual(root.refs[0]);
+      expect(root.model.ref).toStrictEqual(root.refs[0]);
+    });
 
-  test("safe references are equal to the instances they refer to", () => {
-    const root = create(
-      Root,
-      {
-        model: {
-          ref: "item-a",
-          safeRef: "item-b",
+    test("safe references are equal to the instances they refer to", () => {
+      const root = create(
+        Root,
+        {
+          model: {
+            ref: "item-a",
+            safeRef: "item-b",
+          },
+          refs: [
+            { key: "item-a", count: 12 },
+            { key: "item-b", count: 523 },
+          ],
         },
-        refs: [
-          { key: "item-a", count: 12 },
-          { key: "item-b", count: 523 },
-        ],
-      },
-      true,
-    );
+        readOnly,
+      );
 
-    expect(root.model.safeRef).toBe(root.refs[1]);
-    expect(root.model.safeRef).toEqual(root.refs[1]);
-    expect(root.model.safeRef).toStrictEqual(root.refs[1]);
+      expect(root.model.safeRef).toBe(root.refs[1]);
+      expect(root.model.safeRef).toEqual(root.refs[1]);
+      expect(root.model.safeRef).toStrictEqual(root.refs[1]);
+    });
+
+    @register
+    class Weird extends ClassModel({
+      examples: types.map(NameExample),
+      obj: types.union(types.reference(NameExample), Apple),
+    }) {}
+
+    test("unions where one type is a reference can be resolved as references", () => {
+      const instance = create(
+        Weird,
+        {
+          examples: {
+            foo: { key: "foo", name: "foo" },
+          },
+          obj: "foo",
+        },
+        readOnly,
+      );
+
+      expect((instance.obj as NameExample).name).toEqual("foo");
+    });
+
+    test("unions where one type is a reference can be resolved a the non-reference type", () => {
+      const instance = create(
+        Weird,
+        {
+          examples: {
+            foo: { key: "foo", name: "foo" },
+          },
+          obj: { type: "Apple", ripeness: 1 },
+        },
+        readOnly,
+      );
+
+      expect((instance.obj as Apple).ripeness).toEqual(1);
+    });
   });
 });
 

--- a/spec/reference.spec.ts
+++ b/spec/reference.spec.ts
@@ -1,7 +1,7 @@
 import type { Has } from "conditional-type-checks";
 import { assert } from "conditional-type-checks";
-import type { Instance, SnapshotOrInstance } from "../src";
-import { types } from "../src";
+import type { IAnyClassModelType, Instance, SnapshotOrInstance } from "../src";
+import { ClassModel, register, types } from "../src";
 import { TestClassModel } from "./fixtures/TestClassModel";
 import { TestModel, TestModelSnapshot } from "./fixtures/TestModel";
 
@@ -31,30 +31,11 @@ const Root = types.model("Reference Model", {
   refs: types.array(Referrable),
 });
 
-test("can resolve valid references", () => {
-  const root = Root.createReadOnly({
-    model: {
-      ref: "item-a",
-    },
-    refs: [
-      { key: "item-a", count: 12 },
-      { key: "item-b", count: 523 },
-    ],
-  });
-
-  expect(root.model.ref).toEqual(
-    expect.objectContaining({
-      key: "item-a",
-      count: 12,
-    }),
-  );
-});
-
-test("throws for invalid refs", () => {
-  const createRoot = () =>
-    Root.createReadOnly({
+describe("references", () => {
+  test("can resolve valid references", () => {
+    const root = Root.createReadOnly({
       model: {
-        ref: "item-c",
+        ref: "item-a",
       },
       refs: [
         { key: "item-a", count: 12 },
@@ -62,114 +43,317 @@ test("throws for invalid refs", () => {
       ],
     });
 
-  expect(createRoot).toThrow();
-});
-
-test("can resolve valid safe references", () => {
-  const root = Root.createReadOnly({
-    model: {
-      ref: "item-a",
-      safeRef: "item-b",
-    },
-    refs: [
-      { key: "item-a", count: 12 },
-      { key: "item-b", count: 523 },
-    ],
+    expect(root.model.ref).toEqual(
+      expect.objectContaining({
+        key: "item-a",
+        count: 12,
+      }),
+    );
   });
 
-  expect(root.model.safeRef).toEqual(
-    expect.objectContaining({
-      key: "item-b",
-      count: 523,
-    }),
-  );
-});
+  test("throws for invalid refs", () => {
+    const createRoot = () =>
+      Root.createReadOnly({
+        model: {
+          ref: "item-c",
+        },
+        refs: [
+          { key: "item-a", count: 12 },
+          { key: "item-b", count: 523 },
+        ],
+      });
 
-test("does not throw for invalid safe references", () => {
-  const root = Root.createReadOnly({
-    model: {
-      ref: "item-a",
-      safeRef: "item-c",
-    },
-    refs: [
-      { key: "item-a", count: 12 },
-      { key: "item-b", count: 523 },
-    ],
+    expect(createRoot).toThrow();
   });
 
-  expect(root.model.safeRef).toBeUndefined();
-});
+  test("can resolve valid safe references", () => {
+    const root = Root.createReadOnly({
+      model: {
+        ref: "item-a",
+        safeRef: "item-b",
+      },
+      refs: [
+        { key: "item-a", count: 12 },
+        { key: "item-b", count: 523 },
+      ],
+    });
 
-test("references are equal to the instances they refer to", () => {
-  const root = Root.createReadOnly({
-    model: {
-      ref: "item-a",
-      safeRef: "item-b",
-    },
-    refs: [
-      { key: "item-a", count: 12 },
-      { key: "item-b", count: 523 },
-    ],
+    expect(root.model.safeRef).toEqual(
+      expect.objectContaining({
+        key: "item-b",
+        count: 523,
+      }),
+    );
   });
 
-  expect(root.model.ref).toBe(root.refs[0]);
-  expect(root.model.ref).toEqual(root.refs[0]);
-  expect(root.model.ref).toStrictEqual(root.refs[0]);
-});
+  test("does not throw for invalid safe references", () => {
+    const root = Root.createReadOnly({
+      model: {
+        ref: "item-a",
+        safeRef: "item-c",
+      },
+      refs: [
+        { key: "item-a", count: 12 },
+        { key: "item-b", count: 523 },
+      ],
+    });
 
-test("safe references are equal to the instances they refer to", () => {
-  const root = Root.createReadOnly({
-    model: {
-      ref: "item-a",
-      safeRef: "item-b",
-    },
-    refs: [
-      { key: "item-a", count: 12 },
-      { key: "item-b", count: 523 },
-    ],
+    expect(root.model.safeRef).toBeUndefined();
   });
 
-  expect(root.model.safeRef).toBe(root.refs[1]);
-  expect(root.model.safeRef).toEqual(root.refs[1]);
-  expect(root.model.safeRef).toStrictEqual(root.refs[1]);
-});
+  test("references are equal to the instances they refer to", () => {
+    const root = Root.createReadOnly({
+      model: {
+        ref: "item-a",
+        safeRef: "item-b",
+      },
+      refs: [
+        { key: "item-a", count: 12 },
+        { key: "item-b", count: 523 },
+      ],
+    });
 
-test("instances of a model reference are assignable to instances of the model", () => {
-  const instance = TestModel.create(TestModelSnapshot);
-  const referenceType = types.reference(TestModel);
+    expect(root.model.ref).toBe(root.refs[0]);
+    expect(root.model.ref).toEqual(root.refs[0]);
+    expect(root.model.ref).toStrictEqual(root.refs[0]);
+  });
 
-  type instanceType = typeof instance;
-  type referenceInstanceType = Instance<typeof referenceType>;
-  assert<Has<instanceType, referenceInstanceType>>(true);
-  assert<Has<referenceInstanceType, instanceType>>(true);
-});
+  test("safe references are equal to the instances they refer to", () => {
+    const root = Root.createReadOnly({
+      model: {
+        ref: "item-a",
+        safeRef: "item-b",
+      },
+      refs: [
+        { key: "item-a", count: 12 },
+        { key: "item-b", count: 523 },
+      ],
+    });
 
-test("instances of a model reference are assignable to readonly instances of the model", () => {
-  const instance = TestModel.createReadOnly(TestModelSnapshot);
-  const referenceType = types.reference(TestModel);
+    expect(root.model.safeRef).toBe(root.refs[1]);
+    expect(root.model.safeRef).toEqual(root.refs[1]);
+    expect(root.model.safeRef).toStrictEqual(root.refs[1]);
+  });
 
-  type instanceType = typeof instance;
-  type referenceInstanceType = Instance<typeof referenceType>;
-  assert<Has<instanceType, referenceInstanceType>>(true);
-  assert<Has<referenceInstanceType, instanceType>>(true);
-});
+  test("instances of a model reference are assignable to instances of the model", () => {
+    const instance = TestModel.create(TestModelSnapshot);
+    const referenceType = types.reference(TestModel);
 
-test("instances of a class model reference are assignable to instances of the class model", () => {
-  const instance = TestClassModel.create(TestModelSnapshot);
-  const referenceType = types.reference(TestClassModel);
+    type instanceType = typeof instance;
+    type referenceInstanceType = Instance<typeof referenceType>;
+    assert<Has<instanceType, referenceInstanceType>>(true);
+    assert<Has<referenceInstanceType, instanceType>>(true);
+  });
 
-  type instanceType = typeof instance;
-  type referenceInstanceType = Instance<typeof referenceType>;
-  assert<Has<instanceType, referenceInstanceType>>(true);
-  assert<Has<referenceInstanceType, instanceType>>(true);
-});
+  test("instances of a model reference are assignable to readonly instances of the model", () => {
+    const instance = TestModel.createReadOnly(TestModelSnapshot);
+    const referenceType = types.reference(TestModel);
 
-test("instances of a class model reference are assignable to readonly instances of the class model", () => {
-  const instance = TestClassModel.createReadOnly(TestModelSnapshot);
-  const referenceType = types.reference(TestClassModel);
+    type instanceType = typeof instance;
+    type referenceInstanceType = Instance<typeof referenceType>;
+    assert<Has<instanceType, referenceInstanceType>>(true);
+    assert<Has<referenceInstanceType, instanceType>>(true);
+  });
 
-  type instanceType = typeof instance;
-  type referenceInstanceType = Instance<typeof referenceType>;
-  assert<Has<instanceType, referenceInstanceType>>(true);
-  assert<Has<referenceInstanceType, instanceType>>(true);
+  test("instances of a class model reference are assignable to instances of the class model", () => {
+    const instance = TestClassModel.create(TestModelSnapshot);
+    const referenceType = types.reference(TestClassModel);
+
+    type instanceType = typeof instance;
+    type referenceInstanceType = Instance<typeof referenceType>;
+    assert<Has<instanceType, referenceInstanceType>>(true);
+    assert<Has<referenceInstanceType, instanceType>>(true);
+  });
+
+  test("instances of a class model reference are assignable to readonly instances of the class model", () => {
+    const instance = TestClassModel.createReadOnly(TestModelSnapshot);
+    const referenceType = types.reference(TestClassModel);
+
+    type instanceType = typeof instance;
+    type referenceInstanceType = Instance<typeof referenceType>;
+    assert<Has<instanceType, referenceInstanceType>>(true);
+    assert<Has<referenceInstanceType, instanceType>>(true);
+  });
+
+  describe("resolution order", () => {
+    @register
+    class User extends ClassModel({
+      id: types.identifier,
+      name: types.string,
+    }) {}
+
+    @register
+    class Post extends ClassModel({
+      id: types.identifier,
+      title: types.string,
+      author: types.reference(User),
+    }) {}
+
+    // eslint-disable-next-line prefer-const
+    let State: IAnyClassModelType;
+    @register
+    class StateChartState extends ClassModel({
+      id: types.identifier,
+      initialChildState: types.maybe(types.reference(types.late(() => State))),
+      childStates: types.array(types.late(() => State)),
+    }) {}
+    State = StateChartState;
+
+    test("can resolve references when sources are instantiated first", () => {
+      @register
+      class Root extends ClassModel({
+        users: types.map(User),
+        posts: types.map(Post),
+      }) {}
+
+      const root = Root.createReadOnly({
+        users: {
+          "1": { id: "1", name: "Alice" },
+          "2": { id: "2", name: "Bob" },
+        },
+        posts: {
+          "1": { id: "1", title: "First Post", author: "1" },
+          "2": { id: "2", title: "Second Post", author: "2" },
+        },
+      });
+
+      expect(root.posts.get("1")!.author.id).toBe(root.users.get("1")!.id);
+    });
+
+    test("can resolve references when references are instantiated first", () => {
+      @register
+      class Root extends ClassModel({
+        posts: types.map(Post),
+        users: types.map(User),
+      }) {}
+
+      const root = Root.createReadOnly({
+        posts: {
+          "1": { id: "1", title: "First Post", author: "1" },
+          "2": { id: "2", title: "Second Post", author: "2" },
+        },
+        users: {
+          "1": { id: "1", name: "Alice" },
+          "2": { id: "2", name: "Bob" },
+        },
+      });
+
+      expect(root.posts.get("1")!.author.id).toBe(root.users.get("1")!.id);
+    });
+
+    test("can resolve references when late type references are instantiated first", () => {
+      @register
+      class Root extends ClassModel({
+        posts: types.map(types.late(() => Post)),
+        users: types.map(User),
+      }) {}
+
+      const root = Root.createReadOnly({
+        posts: {
+          "1": { id: "1", title: "First Post", author: "1" },
+          "2": { id: "2", title: "Second Post", author: "2" },
+        },
+        users: {
+          "1": { id: "1", name: "Alice" },
+          "2": { id: "2", name: "Bob" },
+        },
+      });
+      expect(root.posts.get("1")!.author.id).toBe(root.users.get("1")!.id);
+    });
+
+    test("can resolve references when maybe references are instantiated first", () => {
+      @register
+      class Root extends ClassModel({
+        posts: types.map(types.maybeNull(Post)),
+        users: types.map(User),
+      }) {}
+
+      const root = Root.createReadOnly({
+        posts: {
+          "1": { id: "1", title: "First Post", author: "1" },
+          "2": { id: "2", title: "Second Post", author: "2" },
+        },
+        users: {
+          "1": { id: "1", name: "Alice" },
+          "2": { id: "2", name: "Bob" },
+        },
+      });
+      expect(root.posts.get("1")!.author.id).toBe(root.users.get("1")!.id);
+    });
+
+    test("can resolve references when references to late types are instantiated first", () => {
+      @register
+      class PostWithLateAuthor extends ClassModel({
+        id: types.identifier,
+        title: types.string,
+        author: types.reference(types.late(() => User)),
+      }) {}
+
+      @register
+      class Root extends ClassModel({
+        posts: types.map(PostWithLateAuthor),
+        users: types.map(User),
+      }) {}
+
+      const root = Root.createReadOnly({
+        posts: {
+          "1": { id: "1", title: "First Post", author: "1" },
+          "2": { id: "2", title: "Second Post", author: "2" },
+        },
+        users: {
+          "1": { id: "1", name: "Alice" },
+          "2": { id: "2", name: "Bob" },
+        },
+      });
+
+      expect(root.posts.get("1")!.author?.id).toBe(root.users.get("1")!.id);
+    });
+
+    test("can resolve references when both source and target are late types", () => {
+      @register
+      class PostWithLateAuthor extends ClassModel({
+        id: types.identifier,
+        title: types.string,
+        author: types.reference(types.late(() => User)),
+      }) {}
+
+      @register
+      class Root extends ClassModel({
+        posts: types.map(types.late(() => PostWithLateAuthor)),
+        users: types.map(types.late(() => User)),
+      }) {}
+
+      const root = Root.createReadOnly({
+        posts: {
+          "1": { id: "1", title: "First Post", author: "1" },
+          "2": { id: "2", title: "Second Post", author: "2" },
+        },
+        users: {
+          "1": { id: "1", name: "Alice" },
+          "2": { id: "2", name: "Bob" },
+        },
+      });
+
+      expect(root.posts.get("1")!.author.id).toBe(root.users.get("1")!.id);
+    });
+
+    test("can resolve nested references", () => {
+      StateChartState.createReadOnly({
+        id: "created",
+        initialChildState: "rightSideUp",
+        childStates: [{ id: "rightSideUp" }],
+      });
+    });
+
+    test("can resolve deeply nested references", () => {
+      StateChartState.createReadOnly({
+        id: "created",
+        initialChildState: "rightSideUp",
+        childStates: [
+          { id: "rightSideUp" },
+          { id: "upsideDown", initialChildState: "left", childStates: [{ id: "left" }, { id: "right" }] },
+        ],
+      });
+    });
+  });
 });

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -11,12 +11,12 @@ import type {
   TreeContext,
 } from "./types";
 
-class MaybeType<Type extends IAnyType> extends BaseType<
+export class MaybeType<Type extends IAnyType> extends BaseType<
   Type["InputType"] | undefined,
   Type["OutputType"] | undefined,
   InstanceWithoutSTNTypeForType<Type> | undefined
 > {
-  constructor(private type: Type) {
+  constructor(readonly type: Type) {
     super(mstTypes.maybe(type.mstType));
   }
 
@@ -39,12 +39,12 @@ class MaybeType<Type extends IAnyType> extends BaseType<
   }
 }
 
-class MaybeNullType<Type extends IAnyType> extends BaseType<
+export class MaybeNullType<Type extends IAnyType> extends BaseType<
   Type["InputType"] | null | undefined,
   Type["OutputType"] | null,
   InstanceWithoutSTNTypeForType<Type> | null
 > {
-  constructor(private type: Type) {
+  constructor(readonly type: Type) {
     super(mstTypes.maybeNull(type.mstType));
   }
 


### PR DESCRIPTION
This fixes a bug in the fast instantiator code where valid references would throw a `can't resolve reference` error due to the instantiation order within MQT. We were accidentally eagerly resolving some references when constructing a tree, where we resolved the reference at reference instantiation time, instead of late resolving them at the very end like we normally do via `context.referenceResolvers`. 

This only happened for wrapped reference types like a `maybe(reference())` or a `late(reference())` because of an instanceof check that failed for wrapped types. Instead, we can use `isReferenceType` from MST to unwrap and answer the real question we are asking.

Fixes https://github.com/gadget-inc/mobx-quick-tree/issues/78, which was an overly broad bug report as it turns out -- class models and normal models correctly late resolve references, regardless of property definition order before this change, it's just when you wrap the reference in a maybe that things got wonky.