### PR TITLE
Add snapshottedViews

### DIFF
--- a/spec/__snapshots__/class-model-snapshotted-views.spec.ts.snap
+++ b/spec/__snapshots__/class-model-snapshotted-views.spec.ts.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`class model snapshotted views an observable instance emits a patch when the view value changes 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      {
+        "op": "replace",
+        "path": "/__snapshottedViewsEpoch",
+        "value": 1,
+      },
+      {
+        "op": "replace",
+        "path": "/__snapshottedViewsEpoch",
+        "value": 0,
+      },
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`class model snapshotted views references references to models with snapshotted views can be instantiated 1`] = `
+{
+  "examples": {
+    "1": {
+      "key": "1",
+      "name": "Alice",
+    },
+    "2": {
+      "key": "2",
+      "name": "Bob",
+    },
+  },
+  "referrers": {
+    "a": {
+      "example": "1",
+      "id": "a",
+    },
+    "b": {
+      "example": "2",
+      "id": "b",
+    },
+  },
+}
+`;

--- a/spec/class-model-snapshotted-views.spec.ts
+++ b/spec/class-model-snapshotted-views.spec.ts
@@ -1,0 +1,211 @@
+import { observable } from "mobx";
+import { ClassModel, action, snapshottedView, getSnapshot, register, types, onPatch } from "../src";
+import { Apple } from "./fixtures/FruitAisle";
+import { create } from "./helpers";
+
+@register
+class ViewExample extends ClassModel({ key: types.identifier, name: types.string }) {
+  @snapshottedView()
+  get slug() {
+    return this.name.toLowerCase().replace(/ /g, "-");
+  }
+
+  @action
+  setName(name: string) {
+    this.name = name;
+  }
+}
+
+@register
+class Outer extends ClassModel({ name: types.string, examples: types.array(ViewExample) }) {
+  @snapshottedView()
+  get upperName() {
+    return this.name.toUpperCase();
+  }
+}
+
+describe("class model snapshotted views", () => {
+  describe.each([
+    ["read-only", true],
+    ["observable", false],
+  ])("%s", (_name, readOnly) => {
+    test("instances don't require the snapshot to include the cache", () => {
+      const instance = create(ViewExample, { key: "1", name: "Test" }, readOnly);
+      expect(instance.slug).toEqual("test");
+    });
+
+    test("models with cached views still correctly report .is on totally different models", () => {
+      const instance = create(ViewExample, { key: "1", name: "Test" }, readOnly);
+      expect(ViewExample.is(instance)).toBe(true);
+      expect(Apple.is(instance)).toBe(false);
+
+      const other = create(Apple, { type: "Apple", ripeness: 1 }, readOnly);
+      expect(ViewExample.is(other)).toBe(false);
+      expect(Apple.is(other)).toBe(true);
+    });
+
+    test("instances of models with all optional properties arent .is of other models with all optional properties", () => {
+      @register
+      class AllOptionalA extends ClassModel({ name: types.optional(types.string, "Jim") }) {}
+
+      @register
+      class AllOptionalB extends ClassModel({ title: types.optional(types.string, "Jest") }) {}
+
+      // the empty snapshot matches both types
+      expect(AllOptionalA.is({})).toBe(true);
+      expect(AllOptionalB.is({})).toBe(true);
+
+      const instanceA = create(AllOptionalA, {}, readOnly);
+      expect(AllOptionalA.is(instanceA)).toBe(true);
+      expect(AllOptionalB.is(instanceA)).toBe(false);
+
+      const instanceB = create(AllOptionalA, {}, readOnly);
+      expect(AllOptionalA.is(instanceB)).toBe(true);
+      expect(AllOptionalB.is(instanceB)).toBe(false);
+    });
+  });
+
+  test("an observable instance ignores the input snapshot value as the logic may have changed", () => {
+    const instance = ViewExample.create({ key: "1", name: "Test", slug: "outdated-cache" } as any);
+    expect(instance.slug).toEqual("test");
+  });
+
+  test("an observable instance emits a patch when the view value changes", () => {
+    const observableArray = observable.array<string>([]);
+
+    @register
+    class MyViewExample extends ClassModel({ key: types.identifier, name: types.string }) {
+      @snapshottedView()
+      get arrayLength() {
+        return observableArray.length;
+      }
+    }
+
+    const fn = jest.fn();
+    const instance = MyViewExample.create({ key: "1", name: "Test" });
+    onPatch(instance, fn);
+
+    observableArray.push("a");
+    expect(fn).toMatchSnapshot();
+  });
+
+  test("an observable instance's snapshot includes the snapshotted views epoch", () => {
+    const instance = ViewExample.create({ key: "1", name: "Test" });
+    expect(getSnapshot(instance)).toEqual({ __snapshottedViewsEpoch: 0, key: "1", name: "Test" });
+  });
+
+  test("a readonly instance's snapshot doesn't include the snapshotted views epoch", () => {
+    const instance = ViewExample.createReadOnly({ key: "1", name: "Test" });
+    expect(getSnapshot(instance)).toEqual({ key: "1", name: "Test" });
+  });
+
+  test("a readonly instance returns the view value from the snapshot if present", () => {
+    const instance = ViewExample.createReadOnly({ key: "1", name: "Test", slug: "test" } as any);
+    expect(instance.slug).toEqual("test");
+  });
+
+  test("a readonly instance doesn't recompute the view value from the snapshot", () => {
+    const instance = ViewExample.createReadOnly({ key: "1", name: "Test", slug: "whatever" } as any);
+    expect(instance.slug).toEqual("whatever");
+  });
+
+  test("a readonly instance doesn't call the computed function if given a snapshot value", () => {
+    const fn = jest.fn();
+    @register
+    class Spy extends ClassModel({ name: types.string }) {
+      @snapshottedView()
+      get slug() {
+        fn();
+        return this.name.toLowerCase().replace(/ /g, "-");
+      }
+    }
+
+    const instance = Spy.createReadOnly({ name: "Test", slug: "whatever" } as any);
+    expect(instance.slug).toEqual("whatever");
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  test("snapshotted views can be passed nested within snapshots", () => {
+    const instance = Outer.createReadOnly({
+      name: "foo",
+      upperName: "SNAPSHOT",
+      examples: [{ key: "1", name: "Test", slug: "test-foobar" } as any, { key: "2", name: "Test 2", slug: "test-qux" } as any],
+    } as any);
+
+    expect(instance.upperName).toEqual("SNAPSHOT");
+    expect(instance.examples[0].slug).toEqual("test-foobar");
+    expect(instance.examples[1].slug).toEqual("test-qux");
+  });
+
+  describe("with a hydrator", () => {
+    @register
+    class HydrateExample extends ClassModel({ url: types.string }) {
+      @snapshottedView<URL>({
+        createReadOnly(value, snapshot, node) {
+          expect(snapshot).toBeDefined();
+          expect(node).toBeDefined();
+          return value ? new URL(value) : undefined;
+        },
+      })
+      get withoutParams() {
+        const url = new URL(this.url);
+        for (const [key] of url.searchParams.entries()) {
+          url.searchParams.delete(key);
+        }
+        return url;
+      }
+
+      @action
+      setURL(url: string) {
+        this.url = url;
+      }
+    }
+
+    test("snapshotted views with processors can be accessed on observable instances", () => {
+      const instance = HydrateExample.create({ url: "https://gadget.dev/blog/feature?utm=whatever" });
+      expect(instance.withoutParams).toEqual(new URL("https://gadget.dev/blog/feature"));
+    });
+
+    test("snapshotted views with processors can be accessed on readonly instances when there's no input data", () => {
+      const instance = HydrateExample.create({ url: "https://gadget.dev/blog/feature?utm=whatever" });
+      expect(instance.withoutParams).toEqual(new URL("https://gadget.dev/blog/feature"));
+    });
+
+    test("snapshotted views with processors can be accessed on readonly instances when there is input data", () => {
+      const instance = HydrateExample.createReadOnly({
+        url: "https://gadget.dev/blog/feature?utm=whatever",
+        withoutParams: "https://gadget.dev/blog/feature/extra", // pass a different value so we can be sure it is what is being used
+      } as any);
+      expect(instance.withoutParams).toEqual(new URL("https://gadget.dev/blog/feature/extra"));
+    });
+  });
+
+  describe("references", () => {
+    @register
+    class Referencer extends ClassModel({
+      id: types.identifier,
+      example: types.reference(ViewExample),
+    }) {}
+
+    @register
+    class Root extends ClassModel({
+      referrers: types.map(Referencer),
+      examples: types.map(ViewExample),
+    }) {}
+
+    test("references to models with snapshotted views can be instantiated", () => {
+      const root = Root.createReadOnly({
+        referrers: {
+          a: { id: "a", example: "1" },
+          b: { id: "b", example: "2" },
+        },
+        examples: {
+          "1": { key: "1", name: "Alice" },
+          "2": { key: "2", name: "Bob" },
+        },
+      });
+
+      expect(getSnapshot(root)).toMatchSnapshot();
+    });
+  });
+});

--- a/spec/class-model.spec.ts
+++ b/spec/class-model.spec.ts
@@ -12,7 +12,7 @@ import type {
   ModelPropertiesDeclaration,
   SnapshotIn,
 } from "../src";
-import { flow, getSnapshot, getType, isReadOnlyNode, isStateTreeNode, isType, types } from "../src";
+import { flow, getSnapshot, getType, isReadOnlyNode, isStateTreeNode, isType, snapshottedView, types } from "../src";
 import { ClassModel, action, extend, register, view, volatile, volatileAction } from "../src/class-model";
 import { $identifier } from "../src/symbols";
 import { NameExample } from "./fixtures/NameExample";
@@ -135,6 +135,17 @@ class ExtendedMixedInNameExample extends extendingClassModelMixin(NameExample) {
   }
 }
 
+/**
+ * Example class wth a snapshotted view
+ */
+@register
+class NameExampleWithSnapshottedView extends NameExample {
+  @snapshottedView()
+  get extendedNameLength() {
+    return this.name.length;
+  }
+}
+
 @register
 class AutoIdentified extends ClassModel({ key: types.optional(types.identifier, () => "test") }) {
   testKeyIsAlwaysSet() {
@@ -180,6 +191,7 @@ describe("class models", () => {
     ["mixin'd class model", MixedInNameExample],
     ["extended props class model", ExtendedNameExample],
     ["extended mixin'd props class model", ExtendedMixedInNameExample],
+    ["class model with snapshotted views", NameExampleWithSnapshottedView],
   ])("%s", (_name, NameExample) => {
     test("types are identified as quick types", () => {
       expect(isType(NameExample)).toBe(true);

--- a/spec/getSnapshot.spec.ts
+++ b/spec/getSnapshot.spec.ts
@@ -79,7 +79,7 @@ describe("getSnapshot", () => {
     assert<IsExact<typeof snapshot.map.test_key, SnapshotOut<typeof NamedThing>>>(true);
   });
 
-  test("snapshots an readonly node model instance", () => {
+  test("snapshots a readonly node model instance", () => {
     const instance = TestModel.createReadOnly(TestModelSnapshot);
     const snapshot = getSnapshot(instance);
     verifySnapshot(snapshot);
@@ -93,7 +93,7 @@ describe("getSnapshot", () => {
     assert<IsExact<typeof snapshot.map.test_key, SnapshotOut<typeof NamedThing>>>(true);
   });
 
-  test("snapshots an readonly class model instance", () => {
+  test("snapshots a readonly class model instance", () => {
     const instance = TestClassModel.createReadOnly(TestModelSnapshot);
     const snapshot = getSnapshot(instance);
     verifySnapshot(snapshot);

--- a/spec/helpers.ts
+++ b/spec/helpers.ts
@@ -1,6 +1,6 @@
 import type { IAnyType, Instance, SnapshotIn } from "../src";
 
-/** Easily reate an observable or readonly instance of a type */
+/** Easily create an observable or readonly instance of a type */
 export const create = <T extends IAnyType>(type: T, snapshot?: SnapshotIn<T>, readOnly = false): Instance<T> => {
   if (readOnly) {
     return type.createReadOnly(snapshot);

--- a/src/api.ts
+++ b/src/api.ts
@@ -74,8 +74,7 @@ export {
   unescapeJsonPath,
   walk,
 } from "mobx-state-tree";
-
-export { ClassModel, action, extend, register, view, volatile, volatileAction } from "./class-model";
+export { ClassModel, action, extend, register, view, snapshottedView, volatile, volatileAction } from "./class-model";
 export { getSnapshot } from "./snapshot";
 
 export const isType = (value: any): value is IAnyType => {

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -1,10 +1,10 @@
 import "reflect-metadata";
 
 import memoize from "lodash.memoize";
-import type { IModelType as MSTIModelType, ModelActions } from "mobx-state-tree";
-import { types as mstTypes } from "mobx-state-tree";
+import type { Instance, IModelType as MSTIModelType, ModelActions } from "mobx-state-tree";
+import { isRoot, types as mstTypes } from "mobx-state-tree";
 import { RegistrationError } from "./errors";
-import { buildFastInstantiator } from "./fast-instantiator";
+import { InstantiatorBuilder } from "./fast-instantiator";
 import { FastGetBuilder } from "./fast-getter";
 import { defaultThrowAction, mstPropsFromQuickProps, propsFromModelPropsDeclaration } from "./model";
 import {
@@ -22,6 +22,7 @@ import {
 import type {
   Constructor,
   ExtendedClassModel,
+  IAnyClassModelType,
   IAnyType,
   IClassModelType,
   IStateTreeNode,
@@ -30,6 +31,8 @@ import type {
   TypesForModelPropsDeclaration,
 } from "./types";
 import { cyrb53 } from "./utils";
+import { comparer, reaction } from "mobx";
+import { getSnapshot } from "./snapshot";
 
 /** @internal */
 type ActionMetadata = {
@@ -38,10 +41,26 @@ type ActionMetadata = {
   volatile: boolean;
 };
 
+/** Options that configure a snapshotted view */
+export interface SnapshottedViewOptions<V, T extends IAnyClassModelType> {
+  /** A function for converting a stored value in the snapshot back to the rich type for the view to return */
+  createReadOnly?: (value: V | undefined, snapshot: T["InputType"], node: Instance<T>) => V | undefined;
+
+  /** A function for converting the view value to a snapshot value */
+  createSnapshot?: (value: V) => any;
+}
+
 /** @internal */
 export type ViewMetadata = {
   type: "view";
   property: string;
+};
+
+/** @internal */
+export type SnapshottedViewMetadata = {
+  type: "snapshotted-view";
+  property: string;
+  options: SnapshottedViewOptions<any, any>;
 };
 
 /** @internal */
@@ -53,7 +72,7 @@ export type VolatileMetadata = {
 
 type VolatileInitializer<T> = (instance: T) => Record<string, any>;
 /** @internal */
-export type PropertyMetadata = ActionMetadata | ViewMetadata | VolatileMetadata;
+export type PropertyMetadata = ActionMetadata | ViewMetadata | SnapshottedViewMetadata | VolatileMetadata;
 
 const metadataPrefix = "mqt:properties";
 const viewKeyPrefix = `${metadataPrefix}:view`;
@@ -158,11 +177,18 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
 
   for (const metadata of metadatas) {
     switch (metadata.type) {
+      case "snapshotted-view":
       case "view": {
         const property = metadata.property;
         const descriptor = getPropertyDescriptor(klass.prototype, property);
         if (!descriptor) {
           throw new RegistrationError(`Property ${property} not found on ${klass} prototype, can't register view for class model`);
+        }
+
+        if ("cache" in metadata && !descriptor.get) {
+          throw new RegistrationError(
+            `Snapshotted view property ${property} on ${klass} must be a getter -- can't use snapshotted views with views that are functions or take arguments`,
+          );
         }
 
         // memoize getters on readonly instances
@@ -177,6 +203,7 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
           ...descriptor,
           enumerable: true,
         });
+
         break;
       }
 
@@ -251,23 +278,57 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
   });
 
   // create the MST type for not-readonly versions of this using the views and actions extracted from the class
-  klass.mstType = mstTypes
+  let mstType = mstTypes
     .model(klass.name, mstPropsFromQuickProps(klass.properties))
     .views((self) => bindToSelf(self, mstViews))
     .actions((self) => bindToSelf(self, mstActions));
 
   if (Object.keys(mstVolatiles).length > 0) {
     // define the volatile properties in one shot by running any passed initializers
-    (klass as any).mstType = (klass as any).mstType.volatile((self: any) => initializeVolatiles({}, self, mstVolatiles));
+    mstType = mstType.volatile((self: any) => initializeVolatiles({}, self, mstVolatiles));
   }
 
+  klass.snapshottedViews = metadatas.filter((metadata) => metadata.type == "snapshotted-view") as SnapshottedViewMetadata[];
+  if (klass.snapshottedViews.length > 0) {
+    // add a property to the MST type to track changes to a @snapshottedView when none of its model's properties changed
+    mstType = mstType
+      .props({ __snapshottedViewsEpoch: mstTypes.optional(mstTypes.number, 0) })
+      .actions((self) => ({ __incrementSnapshottedViewsEpoch: () => self.__snapshottedViewsEpoch++ }))
+      .actions((self) => {
+        const hook = isRoot(self) ? "afterCreate" : "afterAttach";
+        return {
+          [hook]() {
+            reaction(
+              () => {
+                return klass.snapshottedViews.map((sv) => {
+                  const value = self[sv.property];
+                  if (sv.options.createSnapshot) {
+                    return sv.options.createSnapshot(value);
+                  }
+                  if (Array.isArray(value)) {
+                    return value.map(getSnapshot);
+                  }
+                  return getSnapshot(value);
+                });
+              },
+              () => {
+                self.__incrementSnapshottedViewsEpoch();
+              },
+              { equals: comparer.structural },
+            );
+          },
+        };
+      });
+  }
+
+  klass.mstType = mstType;
   (klass as any)[$registered] = true;
 
   // define the class constructor and the following hot path functions dynamically
   //   - .createReadOnly
   //   - .is
   //   - .instantiate
-  return buildFastInstantiator(klass, fastGetters) as any;
+  return new InstantiatorBuilder(klass, fastGetters).build() as any;
 }
 
 /**
@@ -293,6 +354,36 @@ export const view = (target: any, property: string, _descriptor: PropertyDescrip
   const metadata: ViewMetadata = { type: "view", property };
   Reflect.defineMetadata(`${viewKeyPrefix}:${property}`, metadata, target);
 };
+
+/**
+ * Function decorator for registering MQT snapshotted views within MQT class models.
+ *
+ * Can be passed an `options` object with a `createReadOnly` function for transforming the cached value stored in the snapshot from the snapshot state.
+ *
+ * @example
+ * class Example extends ClassModel({ name: types.string }) {
+ *   @snapshottedView()
+ *   get slug() {
+ *     return this.name.toLowerCase().replace(/ /g, "-");
+ *   }
+ * }
+ *
+ * @example
+ * class Example extends ClassModel({ timestamp: types.string }) {
+ *   @snapshottedView({ createReadOnly: (value) => new Date(value) })
+ *   get date() {
+ *     return new Date(timestamp).setTime(0);
+ *   }
+ * }
+ */
+export function snapshottedView<V, T extends IAnyClassModelType = IAnyClassModelType>(
+  options: SnapshottedViewOptions<V, T> = {},
+): (target: any, property: string, _descriptor: PropertyDescriptor) => void {
+  return (target: any, property: string, _descriptor: PropertyDescriptor) => {
+    const metadata: SnapshottedViewMetadata = { type: "snapshotted-view", property, options };
+    Reflect.defineMetadata(`${viewKeyPrefix}:${property}`, metadata, target);
+  };
+}
 
 /**
  * A function for defining a volatile

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -298,24 +298,24 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
         const hook = isRoot(self) ? "afterCreate" : "afterAttach";
         return {
           [hook]() {
-            reaction(
-              () => {
-                return klass.snapshottedViews.map((sv) => {
-                  const value = self[sv.property];
-                  if (sv.options.createSnapshot) {
-                    return sv.options.createSnapshot(value);
+            for (const view of klass.snapshottedViews) {
+              reaction(
+                () => {
+                  const value = self[view.property];
+                  if (view.options.createSnapshot) {
+                    return view.options.createSnapshot(value);
                   }
                   if (Array.isArray(value)) {
                     return value.map(getSnapshot);
                   }
                   return getSnapshot(value);
-                });
-              },
-              () => {
-                self.__incrementSnapshottedViewsEpoch();
-              },
-              { equals: comparer.structural },
-            );
+                },
+                () => {
+                  self.__incrementSnapshottedViewsEpoch();
+                },
+                { equals: comparer.structural },
+              );
+            }
           },
         };
       });

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -44,7 +44,7 @@ type ActionMetadata = {
 /** Options that configure a snapshotted view */
 export interface SnapshottedViewOptions<V, T extends IAnyClassModelType> {
   /** A function for converting a stored value in the snapshot back to the rich type for the view to return */
-  createReadOnly?: (value: V | undefined, snapshot: T["InputType"], node: Instance<T>) => V | undefined;
+  createReadOnly?: (value: V | undefined, node: Instance<T>) => V | undefined;
 
   /** A function for converting the view value to a snapshot value */
   createSnapshot?: (value: V) => any;
@@ -195,7 +195,7 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
         if (descriptor.get) {
           Object.defineProperty(klass.prototype, property, {
             ...descriptor,
-            get: fastGetters.buildGetter(property, descriptor),
+            get: fastGetters.buildViewGetter(metadata, descriptor),
           });
         }
 

--- a/src/fast-instantiator.ts
+++ b/src/fast-instantiator.ts
@@ -1,24 +1,16 @@
-import { isReferenceType, isUnionType } from "mobx-state-tree";
+import { isReferenceType } from "mobx-state-tree";
+import type { IAnyModelType as MSTIAnyModelType, IAnyType as MSTIAnyType } from "mobx-state-tree";
 import { ArrayType, QuickArray } from "./array";
+import type { SnapshottedViewMetadata } from "./class-model";
 import type { FastGetBuilder } from "./fast-getter";
 import { FrozenType } from "./frozen";
 import { MapType, QuickMap } from "./map";
+import { MaybeNullType, MaybeType } from "./maybe";
 import { OptionalType } from "./optional";
 import { ReferenceType, SafeReferenceType } from "./reference";
 import { DateType, IntegerType, LiteralType, SimpleType } from "./simple";
 import { $context, $identifier, $notYetMemoized, $parent, $readOnly, $type } from "./symbols";
 import type { IAnyType, IClassModelType, ValidOptionalValue } from "./types";
-import { MaybeNullType, MaybeType } from "./maybe";
-
-/**
- * Compiles a fast function for taking snapshots and turning them into instances of a class model.
- **/
-export const buildFastInstantiator = <T extends IClassModelType<Record<string, IAnyType>, any, any>>(
-  model: T,
-  fastGetters: FastGetBuilder,
-): T => {
-  return new InstantiatorBuilder(model, fastGetters).build();
-};
 
 type DirectlyAssignableType = SimpleType<any> | IntegerType | LiteralType<any> | DateType;
 const isDirectlyAssignableType = (type: IAnyType): type is DirectlyAssignableType => {
@@ -31,7 +23,10 @@ const isDirectlyAssignableType = (type: IAnyType): type is DirectlyAssignableTyp
   );
 };
 
-class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, any, any>> {
+/**
+ * Compiles a fast class constructor that takes snapshots and turns them into instances of a class model.
+ **/
+export class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, any, any>> {
   aliases = new Map<string, string>();
 
   constructor(
@@ -74,13 +69,18 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
     `);
     }
 
-    const identifierProp = this.model.mstType.identifierAttribute;
+    const modelType = innerModelType(this.model.mstType);
+    const identifierProp = modelType?.identifierAttribute;
     if (identifierProp) {
       segments.push(`
       const id = this["${identifierProp}"];
       this[$identifier] = id;
       context.referenceCache.set(id, this);
     `);
+    }
+
+    for (const [index, snapshottedView] of this.model.snapshottedViews.entries()) {
+      segments.push(this.assignSnapshottedViewExpression(snapshottedView, index));
     }
 
     let className = this.model.name;
@@ -144,7 +144,7 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
     `;
 
     const aliasFuncBody = `
-    const { QuickMap, QuickArray, $identifier, $context, $parent, $notYetMemoized, $readOnly, $type } = imports;
+    const { QuickMap, QuickArray, $identifier, $context, $parent, $notYetMemoized, $readOnly, $type, snapshottedViews } = imports;
 
     ${Array.from(this.aliases.entries())
       .map(([expression, alias]) => `const ${alias} = ${expression};`)
@@ -182,6 +182,7 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
         $notYetMemoized,
         QuickMap,
         QuickArray,
+        snapshottedViews: this.model.snapshottedViews,
       }) as T;
     } catch (e) {
       console.warn("failed to build fast instantiator for", this.model.name);
@@ -331,6 +332,25 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
       }`;
   }
 
+  private assignSnapshottedViewExpression(snapshottedView: SnapshottedViewMetadata, index: number) {
+    const varName = `view${snapshottedView.property}`;
+
+    let valueExpression = `snapshot?.["${snapshottedView.property}"]`;
+    if (snapshottedView.options.createReadOnly) {
+      const alias = this.alias(`snapshottedViews[${index}].options.createReadOnly`);
+      valueExpression = `${alias}(${valueExpression}, snapshot, this)`;
+    }
+    const memoSymbolAlias = this.alias(`Symbol.for("${this.getters.memoSymbolName(snapshottedView.property)}")`);
+
+    return `
+      // setup snapshotted view for ${snapshottedView.property}
+      const ${varName} = ${valueExpression};
+      if (typeof ${varName} != "undefined") {
+        this[${memoSymbolAlias}] = ${varName};
+      }
+    `;
+  }
+
   alias(expression: string): string {
     const existing = this.aliases.get(expression);
     if (existing) {
@@ -344,3 +364,17 @@ class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyType>, an
 }
 
 const safeTypeName = (type: IAnyType) => type.name.replace(/\n/g, "");
+
+const innerModelType = (type: MSTIAnyType): MSTIAnyModelType | undefined => {
+  if ("identifierAttribute" in type) return type as MSTIAnyModelType;
+  if ("getSubTypes" in type) {
+    const subTypes = (type as { getSubTypes(): MSTIAnyType[] | MSTIAnyType | null }).getSubTypes();
+    if (subTypes) {
+      if (Array.isArray(subTypes)) {
+        return innerModelType(subTypes[0]);
+      } else if (subTypes && typeof subTypes == "object") {
+        return innerModelType(subTypes);
+      }
+    }
+  }
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { IInterceptor, IMapDidChange, IMapWillChange, Lambda } from "mobx";
 import type { IAnyType as MSTAnyType } from "mobx-state-tree";
-import type { VolatileMetadata } from "./class-model";
+import type { SnapshottedViewMetadata, VolatileMetadata } from "./class-model";
 import type { $quickType, $registered, $type } from "./symbols";
 
 export type { $quickType, $registered, $type } from "./symbols";
@@ -146,6 +146,9 @@ export interface IClassModelType<
 
   /** @hidden */
   volatiles: Record<string, VolatileMetadata>;
+
+  /** @hidden */
+  snapshottedViews: SnapshottedViewMetadata[];
 
   /** @hidden */
   instantiate(snapshot: this["InputType"] | undefined, context: TreeContext, parent: IStateTreeNode | null): InstanceType<this>;


### PR DESCRIPTION
This is a subset of #69 that only includes re-hydrating `@snapshottedView`'s from a snapshot. This does not include storing the result of a `@snapshottedView`'s value into a snaphot via `getSnapshot` -- that must be done manually.

Gadget side PR showing how it might be used: https://github.com/gadget-inc/gadget/pull/11994

Below is a revised version of #69's description

---

This adds a feature for caching the output of a view in the snapshot of a node. For expensive views, it's nice to compute them at write time, serialize their return values, and then deserialize them in all the readonly contexts instead of computing them. For things like Gadget's action options (or even the string operations to produce the api identifier), we're already computing them once, we can cache that through the snapshot and avoid recomputing them on every read only root. Not all views are snapshotted; you opt in with a `@snapshottedView()` decorator.

As an example, say we have this class:

```typescript
@register
class ViewExample extends ClassModel({ key: types.identifier, name: types.string }) {
  @snapshottedView()
  get slug() {
    return this.name.toLowerCase().replace(/ /g, "-");
  }

  @action
  setName(name: string) {
    this.name = name;
  }
}
```

We can include the `@snapshottedView`'s value in the snapshot:

```typescript
const instance = ViewExample.create({ key: "123", name: "Foous Barius" })
instance.setName("A different name");
const snap = { ...getSnapshot(instance), slug: instance.name }
// => { key: "123", name: "A different name", slug: "a-different-name" }
```

Then, if I create a readonly instance from that snapshot, I can ask for the slug, and the cached value will be returned right away, without calling the view function:

```typescript
const readOnlyInstance = ViewExample.createReadOnly(snap);
readOnlyInstance.slug // => "a-different-name", much faster
```

Yay!

### The details

The devil for this one is in the deep and frankly super intense details about how and when exactly these computations happen. Here's some decision points:

__Must all snapshots have the value for all snapshotted views?__

I vote no so that this feature is incrementally adoptable. If you have a bunch of stored snapshots without a view in them, and then switch a view over to be snapshotted, ideally, the old stored snapshots still work. We have a way to compute the view in both read-only and observable instances that already has nice pure / safe properties, so I think these properties should be optional in the snapshot. 

__What if the definition of the view changes such that recomputing it would produce a different value than the snapshot?__

A great question. Rephrased, this is also asking "what if the incoming snapshot lies about the view value", and the answer is that detecting lies is expensive. We could recompute the view to see if it is correct, but that defeats the performance-win purpose of the cache in the first place. We could store some version number or sigil in the snapshot itself, and only use the value if the version matches, but that seems complicated, and like it would cause some surprise performance issues where code changes all of a sudden caused the caches to stop hitting, but not necessarily cause them to be re-filled with up to date data, getting us stuck in a poor-er performing spot. 

So, I opted to just trust the snapshot, and rely on whatever the thing feeding in the snapshot is to feed in a new one when required. In Gadget's case, the environment version mechanism around a ROSR cache should serve this purpose well, but not everyone else is gonna have that. I think this is a super advanced feature that is ok to have barbs like this.

__Should observable instances care about the value in the snapshot?__

For read-only instances, we should use the snapshot value to avoid running the view and improve performance. But for observable instances, we could "seed" the view with the initial value from the snapshot, or we could just ignore it, and recompute on demand. I think that because of the above view-definition/snapshot-value drift problem, we should do this computation and take the hit. It's also kinda complicated to seed the value of a computed like this, but I am sure we could make it work if we had to. I kinda like the distinction of "observable instances are the authority and work in the pure, nice way that MST does", and "readonly instances are bastardized to all hell to make them as performant as possible, which is ok, because they are readonly and won't ever be written back to disk".