### PR TITLE
Add shouldTrackChanges option to @snapshottedView

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,8 @@ const readOnlyExample = TransformExample.createReadOnly(snapshot);
 readOnlyExample.withoutParams; // => URL { href: "https://example.com" }
 ```
 
+Snapshotted views emit patches when their values change. If you don't want snapshotted views to emit a patch when they change, you can pass a `shouldEmitPatchOnChange` function that returns `false` to the `@snapshottedView`, or you can pass `false` to `setDefaultShouldEmitPatchOnChange` to disable patch emission for all snapshotted views.
+
 ##### Snapshotted view semantics
 
 Snapshotted views are a complicated beast, and are best avoided until your performance demands less computation on readonly instances.


### PR DESCRIPTION
This adds `shouldEmitPatchOnChange` to `@snapshottedView`'s options so users can opt of emitting patches when snapshotted views for changes.

Tracking snapshotted views causes them to be immediately computed which isn't ideal if you don't need to track their changes.