### PR TITLE
Default shouldEmitPatchOnChange to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ const readOnlyExample = TransformExample.createReadOnly(snapshot);
 readOnlyExample.withoutParams; // => URL { href: "https://example.com" }
 ```
 
-Snapshotted views emit patches when their values change. If you don't want snapshotted views to emit a patch when they change, you can pass a `shouldEmitPatchOnChange` function that returns `false` to the `@snapshottedView`, or you can pass `false` to `setDefaultShouldEmitPatchOnChange` to disable patch emission for all snapshotted views.
+If your snapshotted views need to emit patches when their values change, you can pass a `shouldEmitPatchOnChange` function that returns `true` to the `@snapshottedView` decorator, or you can pass `true` to `setDefaultShouldEmitPatchOnChange` to enable patch emission for all snapshotted views.
 
 ##### Snapshotted view semantics
 

--- a/spec/__snapshots__/class-model-snapshotted-views.spec.ts.snap
+++ b/spec/__snapshots__/class-model-snapshotted-views.spec.ts.snap
@@ -1,30 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`class model snapshotted views an observable instance emits a patch when the view value changes 1`] = `
-[MockFunction] {
-  "calls": [
-    [
-      {
-        "op": "replace",
-        "path": "/__snapshottedViewsEpoch",
-        "value": 1,
-      },
-      {
-        "op": "replace",
-        "path": "/__snapshottedViewsEpoch",
-        "value": 0,
-      },
-    ],
-  ],
-  "results": [
-    {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
-`;
-
 exports[`class model snapshotted views references references to models with snapshotted views can be instantiated 1`] = `
 {
   "examples": {

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -560,7 +560,7 @@ export const isClassModel = (type: IAnyType): type is IClassModelType<any, any, 
   return (type as any).isMQTClassModel;
 };
 
-let defaultShouldEmitPatchOnChange = true;
+let defaultShouldEmitPatchOnChange = false;
 
 /**
  * Sets the default value for the `shouldEmitPatchOnChange` option for


### PR DESCRIPTION
We added `shouldEmitPatchOnChange` in #107, but defaulted it to true.

After starting to use `shouldEmitPatchOnChange` in Gadget, we realized that users should opt-in to emitting patches for snapshotted view changes rather than having to opt-out. This PR fixes that.

This is technically a breaking change but since so few people use mobx-quick-tree and #107 has been released for less than 24h this should be fine.