### PR TITLE
Add support for acceptsUndefined: false to safe references

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gadgetinc/mobx-quick-tree",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "A mirror of mobx-state-tree's API to construct fast, read-only instances that share all the same views",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
@@ -65,8 +65,5 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
     "yargs": "^17.7.2"
-  },
-  "volta": {
-    "node": "18.12.1"
   }
 }

--- a/src/map.ts
+++ b/src/map.ts
@@ -15,6 +15,7 @@ import type {
   TreeContext,
   SnapshotOut,
 } from "./types";
+import { SafeReferenceType } from "./reference";
 
 export class QuickMap<T extends IAnyType> extends Map<string, Instance<T>> implements IMSTMap<T> {
   static get [Symbol.species]() {
@@ -112,6 +113,12 @@ export class MapType<T extends IAnyType> extends BaseType<
     if (snapshot) {
       for (const key in snapshot) {
         const item = this.childrenType.instantiate(snapshot[key], context, map);
+        if (this.childrenType instanceof SafeReferenceType && this.childrenType.options?.acceptsUndefined === false) {
+          if (item == null) {
+            continue;
+          }
+        }
+
         map.set(key, item);
       }
     }

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -55,7 +55,7 @@ export class SafeReferenceType<TargetType extends IAnyComplexType> extends BaseT
 > {
   constructor(
     readonly targetType: IAnyComplexType,
-    options?: SafeReferenceOptions<TargetType>,
+    readonly options?: SafeReferenceOptions<TargetType>,
   ) {
     super(types.safeReference(targetType.mstType, options));
   }
@@ -85,10 +85,15 @@ export const reference = <TargetType extends IAnyComplexType>(
   return new ReferenceType(targetType, options);
 };
 
-export const safeReference = <TargetType extends IAnyComplexType>(
+export function safeReference<IT extends IAnyComplexType>(
+  subType: IT,
+  options: SafeReferenceOptions<IT> & { acceptsUndefined: false },
+): IReferenceType<IT>;
+export function safeReference<IT extends IAnyComplexType>(subType: IT, options?: SafeReferenceOptions<IT>): IMaybeType<IReferenceType<IT>>;
+export function safeReference<TargetType extends IAnyComplexType>(
   targetType: TargetType,
   options?: SafeReferenceOptions<TargetType>,
-): IMaybeType<IReferenceType<TargetType>> => {
+): IMaybeType<IReferenceType<TargetType>> {
   ensureRegistered(targetType);
   return new SafeReferenceType(targetType, options);
-};
+}


### PR DESCRIPTION
MST proper supports an `acceptsUndefined: false` on safe references that automatically prunes invalid references from parent maps and arrays. I wanna use it in Gadget but noticed that it no worky -- we pass the option through to observable instances fine but didn't do anything with it in readonly instances. This adds handling for the special case, which requires arrays and maps to look at the child type, and if it is a safe reference with the option set, omit unresolved entries from the result. Woop woop.
