### PR TITLE
Don't re-bind views to this -- MST gives them the right `this` by moving them right onto self

### DIFF
--- a/bench/cross-framework.benchmark.ts
+++ b/bench/cross-framework.benchmark.ts
@@ -29,6 +29,9 @@ export default benchmarker(async (suite) => {
     .add("mobx-quick-tree types.model", function () {
       TestModel.createReadOnly(TestModelSnapshot);
     })
+    .add("mobx-state-tree ClassModel", function () {
+      TestClassModel.create(TestModelSnapshot);
+    })
     .add("mobx-quick-tree ClassModel", function () {
       TestClassModel.createReadOnly(TestModelSnapshot);
     })
@@ -39,5 +42,5 @@ export default benchmarker(async (suite) => {
       new TestPlainModel(TestModelSnapshot);
     });
 
-  return suite
+  return suite;
 });

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -284,11 +284,14 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
   });
 
   // create the MST type for not-readonly versions of this using the views and actions extracted from the class
-  let mstType = mstTypes
-    .model(klass.name, mstPropsFromQuickProps(klass.properties))
-    .views((self) => bindToSelf(self, mstViews))
-    .actions((self) => bindToSelf(self, mstActions));
 
+  let mstType = mstTypes.model(klass.name, mstPropsFromQuickProps(klass.properties));
+  if (Object.keys(mstViews).length > 0) {
+    mstType = mstType.views(() => mstViews);
+  }
+  if (Object.keys(mstActions).length > 0) {
+    mstType = mstType.actions((self) => bindToSelf(self, mstActions));
+  }
   if (Object.keys(mstVolatiles).length > 0) {
     // define the volatile properties in one shot by running any passed initializers
     mstType = mstType.volatile((self: any) => initializeVolatiles({}, self, mstVolatiles));


### PR DESCRIPTION
When setting up class models, we had to do a bunch of stuff to allow `this.stuff` to work within a class model view or action function. Class models refer to themselves as a `this` for performance in the read only world, but MST uses closures over `self`. We use `bindToSelf` to forcibly bind all the functions to use `self` for this. 

We don't need to actually do this bind for views however -- mst will execute them with the right `this` kind of by accident! MST defines the views right on the observable object itself, so without any mucking about the `this` is correct. Better yet, we know that the incoming view functions from an MQT class aren't weirdly bound to some other `this` as that doesn't work with MQT in the first place.

Regrettably, we do however need to continue to do this bind for actions, as mst will execute them with a weird `this` otherwise. It binds each action to the object returned by the `actions(self => ({ ... }))` function here: https://github.com/mobxjs/mobx-state-tree/blob/cb26163cd56c8d834ef31c6abb8b4ea4e7525dbd/src/types/complex-types/model.ts#L448-L451, and we don't want that, we want `this` to be `self`. Annoying! And poorly performing!

Passing Gadget CI here: https://github.com/gadget-inc/gadget/pull/15452