### PR TITLE
Run codspeed on `pull_request` event to have better PR reports

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,9 @@
 name: "Benchmark"
 on:
   push:
+    branches:
+      - main
+  pull_request:
   workflow_call:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
I noticed that the `pull_request` event was not used to run CodSpeed on the repo.

This leads to [incorrect base selection](https://codspeed.io/docs/features/understanding-the-metrics#baseline-report-selection), since the branch algorithm will be used instead of the pull request one. You can see the issue [in this PR](https://github.com/gadget-inc/mobx-quick-tree/pull/126#issuecomment-3059130944) for example, a previous commit of the head branch was chosen as the base instead of the PR base.

Using `pull_request` instead of `push` will fix that 😉

FYI, to avoid this kind of things in the future, we are soon going to stop commenting on pull request when a run was triggered with `push`.