### PR TITLE
Only track instances with incoming references in the reference cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,6 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.7.2",
     "yargs": "^17.7.2"
-  }
+  },
+  "packageManager": "pnpm@9.11.0+sha512.0a203ffaed5a3f63242cd064c8fb5892366c103e328079318f78062f24ea8c9d50bc6a47aa3567cabefd824d170e78fa2745ed1f16b132e16436146b7688f19b"
 }

--- a/spec/reference.spec.ts
+++ b/spec/reference.spec.ts
@@ -506,4 +506,164 @@ describe("references", () => {
       });
     });
   });
+
+  describe("reference tracking optimization", () => {
+    test("only caches types that have identifiers or are referenced", () => {
+      // Create a type with an identifier - should always be cached
+      @register
+      class WithIdentifier extends ClassModel({
+        id: types.identifier,
+        name: types.string,
+      }) {}
+
+      // Create a type without identifier and not referenced - should NOT be cached
+      @register
+      class WithoutIdentifierNotReferenced extends ClassModel({
+        name: types.string,
+        value: types.number,
+      }) {}
+
+      // Create a type without identifier but IS referenced - should be cached when referenced
+      @register
+      class WithoutIdentifierButReferenced extends ClassModel({
+        id: types.identifier, // Give it an identifier so we can reference it
+        name: types.string,
+        value: types.number,
+      }) {}
+
+      // Create a root that references one type but not the other
+      @register
+      class Root extends ClassModel({
+        withId: WithIdentifier,
+        withoutIdNotReferenced: WithoutIdentifierNotReferenced,
+        referencedType: types.reference(WithoutIdentifierButReferenced),
+        referencedInstances: types.array(WithoutIdentifierButReferenced),
+      }) {}
+
+      // Create an instance and check what's in the reference cache
+      const root = Root.createReadOnly({
+        withId: { id: "test-id", name: "Test" },
+        withoutIdNotReferenced: { name: "Not Cached", value: 42 },
+        referencedType: "ref-1",
+        referencedInstances: [
+          { id: "ref-1", name: "Referenced 1", value: 1 },
+          { id: "ref-2", name: "Referenced 2", value: 2 },
+        ],
+      });
+
+      // Access the context to check the reference cache
+      const context = (root as any)[Symbol.for("MQT_context")];
+      const referenceCache = context.referenceCache;
+
+      // Should contain instances with identifiers
+      expect(referenceCache.has("test-id")).toBe(true); // WithIdentifier
+      expect(referenceCache.has("ref-1")).toBe(true); // WithoutIdentifierButReferenced
+      expect(referenceCache.has("ref-2")).toBe(true); // WithoutIdentifierButReferenced
+
+      // Get all cached identifiers
+      const cachedIds = Array.from(referenceCache.keys()).sort();
+
+      // Should contain all identifiers since all these types have identifiers
+      expect(cachedIds).toEqual(["ref-1", "ref-2", "test-id"]);
+
+      // The optimization works by not caching the WithoutIdentifierNotReferenced instance
+      // since it has no identifier (so it can't be cached anyway) and isn't referenced
+      // The real optimization is in memory usage - we don't track unnecessary references
+    });
+
+    test("handles circular late type references correctly", () => {
+      @register
+      class User extends ClassModel({
+        id: types.identifier,
+        name: types.string,
+      }) {}
+
+      @register
+      class Post extends ClassModel({
+        id: types.identifier,
+        title: types.string,
+        author: types.reference(User),
+      }) {}
+
+      @register
+      class Root extends ClassModel({
+        // Use late types to create potential circular dependencies
+        posts: types.map(types.late(() => Post)),
+        users: types.map(types.late(() => User)),
+      }) {}
+
+      // This should work without throwing errors about circular dependencies
+      const root = Root.createReadOnly({
+        posts: {
+          "1": { id: "1", title: "First Post", author: "1" },
+        },
+        users: {
+          "1": { id: "1", name: "Alice" },
+        },
+      });
+
+      // Verify the reference was resolved correctly
+      expect(root.posts.get("1")!.author.id).toBe("1");
+      expect(root.posts.get("1")!.author.name).toBe("Alice");
+
+      // Check that both User and Post instances are cached (they have identifiers)
+      const context = (root as any)[Symbol.for("MQT_context")];
+      const referenceCache = context.referenceCache;
+
+      expect(referenceCache.has("1")).toBe(true); // User with id "1"
+      expect(referenceCache.get("1")).toBe(root.users.get("1"));
+    });
+
+    test("works with nested references in complex type structures", () => {
+      @register
+      class Category extends ClassModel({
+        id: types.identifier,
+        name: types.string,
+      }) {}
+
+      @register
+      class Product extends ClassModel({
+        id: types.identifier,
+        name: types.string,
+        category: types.reference(Category),
+      }) {}
+
+      @register
+      class Order extends ClassModel({
+        id: types.identifier,
+        products: types.array(types.reference(Product)),
+      }) {}
+
+      @register
+      class Root extends ClassModel({
+        categories: types.map(Category),
+        products: types.map(Product),
+        orders: types.map(Order),
+      }) {}
+
+      const root = Root.createReadOnly({
+        categories: {
+          cat1: { id: "cat1", name: "Electronics" },
+        },
+        products: {
+          prod1: { id: "prod1", name: "Laptop", category: "cat1" },
+        },
+        orders: {
+          order1: { id: "order1", products: ["prod1"] },
+        },
+      });
+
+      // Verify all references resolve correctly
+      expect(root.orders.get("order1")!.products[0].name).toBe("Laptop");
+      expect(root.orders.get("order1")!.products[0].category.name).toBe("Electronics");
+
+      // All these types have identifiers, so they should all be cached
+      const context = (root as any)[Symbol.for("MQT_context")];
+      const referenceCache = context.referenceCache;
+
+      expect(referenceCache.has("cat1")).toBe(true);
+      expect(referenceCache.has("prod1")).toBe(true);
+      expect(referenceCache.has("order1")).toBe(true);
+    });
+  });
 });

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -740,9 +740,19 @@ export function shouldTrackInReferenceCache(classModel: IAnyType, typeToCheck: I
     (classModel as any)._referencedTypes = referencedTypes;
   }
 
-  // Use schema hash for comparison
-  const typeToCheckHash = typeToCheck.schemaHash();
-  return referencedTypes.has(typeToCheckHash);
+  // Fast path: if no types are referenced, don't cache
+  if (referencedTypes.size === 0) {
+    return false;
+  }
+
+  // Use schema hash for comparison - cache the hash to avoid recomputation
+  let typeHash = (typeToCheck as any)._cachedSchemaHash;
+  if (!typeHash) {
+    typeHash = typeToCheck.schemaHash();
+    (typeToCheck as any)._cachedSchemaHash = typeHash;
+  }
+
+  return referencedTypes.has(typeHash);
 }
 
 let defaultShouldEmitPatchOnChange = false;

--- a/src/class-model.ts
+++ b/src/class-model.ts
@@ -2,11 +2,16 @@ import "reflect-metadata";
 
 import memoize from "lodash.memoize";
 import type { Instance, IModelType as MSTIModelType, ModelActions } from "mobx-state-tree";
-import { types as mstTypes } from "mobx-state-tree";
+import { isReferenceType, types as mstTypes } from "mobx-state-tree";
+import { ArrayType } from "./array";
 import { RegistrationError } from "./errors";
 import { InstantiatorBuilder } from "./fast-instantiator";
 import { FastGetBuilder } from "./fast-getter";
+import { MapType } from "./map";
+import { MaybeType, MaybeNullType } from "./maybe";
 import { defaultThrowAction, mstPropsFromQuickProps, propsFromModelPropsDeclaration } from "./model";
+import { OptionalType } from "./optional";
+import { ReferenceType, SafeReferenceType } from "./reference";
 import {
   $context,
   $identifier,
@@ -23,6 +28,8 @@ import type {
   Constructor,
   ExtendedClassModel,
   IAnyClassModelType,
+  IAnyComplexType,
+  IAnyModelType,
   IAnyType,
   IClassModelType,
   IStateTreeNode,
@@ -142,6 +149,148 @@ export const ClassModel = <PropsDeclaration extends ModelPropertiesDeclaration>(
     static properties = props;
   } as any;
 };
+
+/**
+ * Compute which types are referenced by this class model.
+ * This enables optimization where only instances of referenced types are cached.
+ * Uses schema hash for reliable type identification.
+ */
+export function computeReferencedTypes(klass: IClassModelType<any>): Map<string, IAnyComplexType> {
+  const referencedTypes = new Map<string, IAnyComplexType>();
+  const visited = new Set<IAnyType>();
+
+  function traverseType(type: IAnyType): void {
+    if (visited.has(type)) {
+      return; // Avoid infinite recursion
+    }
+    visited.add(type);
+
+    // Handle reference types - these are the types we want to track
+    if (type instanceof ReferenceType || type instanceof SafeReferenceType) {
+      const targetType = type.targetType;
+      const hash = targetType.schemaHash();
+      referencedTypes.set(hash, targetType);
+      // Also traverse the target type in case it has nested references
+      traverseType(targetType);
+      return;
+    }
+
+    // Handle MST reference types that aren't wrapped in our types
+    if (isReferenceType(type.mstType)) {
+      // For MST reference types, we can't easily get the target type,
+      // so we'll be conservative and mark all complex types as potentially referenced
+      // This maintains backward compatibility
+      return;
+    }
+
+    // Handle container types
+    if (type instanceof ArrayType) {
+      traverseType(type.childrenType);
+    } else if (type instanceof MapType) {
+      traverseType(type.childrenType);
+    } else if (type instanceof OptionalType) {
+      traverseType(type.type);
+    } else if (type instanceof MaybeType || type instanceof MaybeNullType) {
+      traverseType(type.type);
+    } else if (isUnionType(type)) {
+      // Handle union types via duck typing
+      const types = (type as any).types;
+      if (Array.isArray(types)) {
+        for (const unionType of types) {
+          traverseType(unionType);
+        }
+      }
+    } else if (isLateType(type)) {
+      // For late types, we need to resolve them to traverse their contents
+      try {
+        const resolvedType = resolveLateType(type);
+        if (resolvedType) {
+          traverseType(resolvedType);
+        }
+        // If late type couldn't be resolved, skip it - this preserves lazy evaluation
+      } catch {
+        // If we can't resolve the late type yet, skip it - this preserves lazy evaluation
+      }
+    } else if (isClassModel(type) || isModelType(type)) {
+      // Traverse model properties
+      for (const propType of Object.values(type.properties)) {
+        traverseType(propType as IAnyType);
+      }
+    }
+  }
+
+  // Start traversal from this class model
+  traverseType(klass);
+
+  return referencedTypes;
+}
+
+/**
+ * Check if a type is a union type (duck typing)
+ */
+function isUnionType(type: IAnyType): boolean {
+  return type.constructor.name === "UnionType" || (Array.isArray((type as any).types) && (type as any).dispatcher !== undefined);
+}
+
+/**
+ * Check if a type is a late type (duck typing)
+ */
+function isLateType(type: IAnyType): boolean {
+  return type.constructor.name === "LateType" || (type as any).cachedType !== undefined || type.mstType?.name?.startsWith("late(");
+}
+
+/**
+ * Resolve a late type to get its actual type
+ */
+function resolveLateType(type: IAnyType): IAnyType | null {
+  try {
+    // For LateType instances, access the type getter which will trigger resolution
+    if (type.constructor.name === "LateType") {
+      const lateType = type as any;
+      // Access the type getter to trigger lazy resolution
+      return lateType.type;
+    }
+
+    // Fallback: try to access a type property
+    if ("type" in type && typeof (type as any).type === "object") {
+      return (type as any).type;
+    }
+  } catch {
+    // Late type not ready for resolution or circular dependency
+  }
+  return null;
+}
+
+/**
+ * Check if a type is a model type (class model or node model)
+ */
+function isModelType(type: IAnyType): type is IAnyModelType {
+  return "properties" in type && typeof type.properties === "object";
+}
+
+/**
+ * Check if a type has an identifier property
+ */
+function hasIdentifier(type: IAnyType): boolean {
+  // For class models, check if any property is an identifier
+  if (isClassModel(type)) {
+    for (const propType of Object.values(type.properties)) {
+      const prop = propType as IAnyType;
+      // Check if this property is an identifier type
+      if (prop.mstType && prop.mstType.name === "identifier") {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // For MST model types, check if they have an identifierAttribute
+  if (type.mstType && "identifierAttribute" in type.mstType) {
+    return !!(type.mstType as any).identifierAttribute;
+  }
+
+  return false;
+}
 
 /**
  * Class decorator for registering MQT class models as setup.
@@ -342,6 +491,10 @@ export function register<Instance, Klass extends { new (...args: any[]): Instanc
 
   klass.mstType = mstType;
   (klass as any)[$registered] = true;
+
+  // Don't compute referenced types at registration time - do it lazily on first instantiation
+  // to handle circular late type references properly
+  (klass as any)._referencedTypes = null;
 
   // define the class constructor and the following hot path functions dynamically
   //   - .createReadOnly
@@ -562,6 +715,35 @@ export function getPropertyDescriptor(obj: any, property: string) {
 export const isClassModel = (type: IAnyType): type is IClassModelType<any, any, any> => {
   return (type as any).isMQTClassModel;
 };
+
+/**
+ * Check if a type should be tracked in the reference cache for a given class model.
+ * Only applies to class models - other types will always return true to maintain compatibility.
+ */
+export function shouldTrackInReferenceCache(classModel: IAnyType, typeToCheck: IAnyComplexType): boolean {
+  // Only apply optimization to class models
+  if (!isClassModel(classModel)) {
+    return true; // Always track for non-class models
+  }
+
+  // Always cache types that have identifiers, regardless of whether they're referenced,
+  // because they might be looked up via resolveIdentifier() API calls
+  if (hasIdentifier(typeToCheck)) {
+    return true;
+  }
+
+  // For types without identifiers, only cache them if they're actually referenced
+  // Lazily compute referenced types on first access to handle circular late type references
+  let referencedTypes = (classModel as any)._referencedTypes as Map<string, IAnyComplexType> | null;
+  if (referencedTypes === null) {
+    referencedTypes = computeReferencedTypes(classModel);
+    (classModel as any)._referencedTypes = referencedTypes;
+  }
+
+  // Use schema hash for comparison
+  const typeToCheckHash = typeToCheck.schemaHash();
+  return referencedTypes.has(typeToCheckHash);
+}
 
 let defaultShouldEmitPatchOnChange = false;
 

--- a/src/fast-instantiator.ts
+++ b/src/fast-instantiator.ts
@@ -8,6 +8,7 @@ import { MapType, QuickMap } from "./map";
 import { MaybeNullType, MaybeType } from "./maybe";
 import { OptionalType } from "./optional";
 import { ReferenceType, SafeReferenceType } from "./reference";
+import { shouldTrackInReferenceCache, computeReferencedTypes } from "./class-model";
 import { DateType, IntegerType, LiteralType, SimpleType } from "./simple";
 import { $context, $identifier, $notYetMemoized, $parent, $readOnly, $type } from "./symbols";
 import type { IAnyType, IClassModelType, ValidOptionalValue } from "./types";
@@ -75,7 +76,11 @@ export class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyTy
       segments.push(`
       const id = this["${identifierProp}"];
       this[$identifier] = id;
-      context.referenceCache.set(id, this);
+
+      // Cache this instance in the reference cache if this type is referenced anywhere in the type tree
+      if (${this.alias("shouldTrackInReferenceCache")}(context.rootType || ${this.alias("model")}, ${this.alias("model")})) {
+        context.referenceCache.set(id, this);
+      }
     `);
     }
 
@@ -91,10 +96,16 @@ export class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyTy
     const defineClassStatement = `
       class ${className} extends model {
         static createReadOnly = (snapshot, env) => {
+          // Lazily compute referenced types on first instantiation to handle circular late types
+          if (model._referencedTypes === null) {
+            model._referencedTypes = ${this.alias("computeReferencedTypes")}(model);
+          }
+          
           const context = {
             referenceCache: new Map(),
             referencesToResolve: [],
             env,
+            rootType: ${className},
           };
 
           const instance = new ${className}(snapshot, context, null);
@@ -155,7 +166,7 @@ export class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyTy
     `;
 
     const aliasFuncBody = `
-    const { QuickMap, QuickArray, $identifier, $context, $parent, $notYetMemoized, $readOnly, $type, snapshottedViews } = imports;
+    const { QuickMap, QuickArray, $identifier, $context, $parent, $notYetMemoized, $readOnly, $type, snapshottedViews, shouldTrackInReferenceCache, computeReferencedTypes } = imports;
 
     ${Array.from(this.aliases.entries())
       .map(([expression, alias]) => `const ${alias} = ${expression};`)
@@ -194,6 +205,8 @@ export class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyTy
         QuickMap,
         QuickArray,
         snapshottedViews: this.model.snapshottedViews,
+        shouldTrackInReferenceCache,
+        computeReferencedTypes,
       }) as T;
     } catch (e) {
       console.warn("failed to build fast instantiator for", this.model.name);

--- a/src/fast-instantiator.ts
+++ b/src/fast-instantiator.ts
@@ -77,7 +77,7 @@ export class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyTy
       const id = this["${identifierProp}"];
       this[$identifier] = id;
 
-      // Cache this instance in the reference cache if this type is referenced anywhere in the type tree
+      // Cache this instance in the reference cache if this type is actually referenced anywhere in the type tree
       if (${this.alias("shouldTrackInReferenceCache")}(context.rootType || ${this.alias("model")}, ${this.alias("model")})) {
         context.referenceCache.set(id, this);
       }
@@ -105,7 +105,7 @@ export class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyTy
             referenceCache: new Map(),
             referencesToResolve: [],
             env,
-            rootType: ${className},
+            rootType: model,
           };
 
           const instance = new ${className}(snapshot, context, null);
@@ -160,7 +160,7 @@ export class InstantiatorBuilder<T extends IClassModelType<Record<string, IAnyTy
         }
 
         get [$type]() {
-          return this.constructor;
+          return model;
         }
       }
     `;

--- a/src/model.ts
+++ b/src/model.ts
@@ -5,6 +5,7 @@ import { types } from ".";
 import { BaseType } from "./base";
 import { ensureRegistered } from "./class-model";
 import { CantRunActionError } from "./errors";
+import { shouldTrackInReferenceCache } from "./class-model";
 import { $context, $identifier, $originalDescriptor, $parent, $readOnly, $type } from "./symbols";
 import type {
   IAnyStateTreeNode,
@@ -93,6 +94,7 @@ export const instantiateInstanceFromProperties = (
   properties: ModelProperties,
   identifierProp: string | undefined,
   context: TreeContext,
+  typeObject?: IAnyType, // Add optional type parameter
 ) => {
   for (const propName in properties) {
     const propType = properties[propName];
@@ -109,7 +111,13 @@ export const instantiateInstanceFromProperties = (
   if (identifierProp) {
     const id = instance[identifierProp];
     instance[$identifier] = id;
-    context.referenceCache.set(id, instance);
+    // Only cache in reference cache if this type is actually referenced
+    // Use the type object passed in, or try to get it from the instance
+    const actualType = typeObject || instance[$type];
+    const rootType = context.rootType || actualType;
+    if (actualType && shouldTrackInReferenceCache(rootType, actualType)) {
+      context.referenceCache.set(id, instance);
+    }
   }
 };
 
@@ -281,7 +289,7 @@ export class ModelType<Props extends ModelProperties, Others> extends BaseType<
       },
     });
 
-    instantiateInstanceFromProperties(instance, snapshot, this.properties, this.identifierProp, context);
+    instantiateInstanceFromProperties(instance, snapshot, this.properties, this.identifierProp, context, this);
     for (let index = 0; index < this.initializers.length; index++) {
       this.initializers[index](instance);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,6 +258,8 @@ export interface TreeContext {
   referenceCache: Map<string, Instance<IAnyNodeModelType>>;
   referencesToResolve: (() => void)[];
   env?: unknown;
+  /** @hidden - The root type that initiated this createReadOnly call */
+  rootType?: IAnyType;
 }
 
 /**


### PR DESCRIPTION
- **Make schemaHash synchronous so we can use it for type identity in sync contexts**
- **Only add models that might need dereferencing to the reference cache**
